### PR TITLE
feat(ui): 시작 노드 선택 중 맵 이동 허용

### DIFF
--- a/src/ui/map_overlay.lua
+++ b/src/ui/map_overlay.lua
@@ -292,10 +292,6 @@ function MapOverlay:update(dt)
 
   self.close_button:update(dt)
 
-  if self.start_select_mode then
-    return
-  end
-
   if self.drag_active then
     if not love.mouse.isDown(1) then
       self.drag_active = false


### PR DESCRIPTION
## 변경 내용\n- start_select_mode 에서도 맵 드래그 이동 가능\n- start_select_mode 에서도 휠 이동 가능\n- 시작 노드 클릭 선택 동작은 기존처럼 유지\n- 시작 노드 선택 안내 문구에 경로 탐색(Drag/Wheel) 힌트 추가\n\n## 의도\n보스까지 경로를 확인한 뒤 시작 노드를 선택할 수 있도록, 시작 노드 선택 단계의 맵 탐색성을 높입니다.\n\n## 검증\n- love . (5초 실행, 에러 없음)