### PR TITLE
fix(combat): 대상 선택형 마법 타깃 로직 수정

### DIFF
--- a/src/combat/prediction_engine.lua
+++ b/src/combat/prediction_engine.lua
@@ -256,7 +256,12 @@ function PredictionEngine:_resolve_spell_target(scaffold, hero, enemies)
     return scaffold.target
   end
 
-  if effect.type == 'damage' or effect.type == 'debuff_attack' or effect.type == 'debuff_speed' then
+  if effect.type == 'global' then
+    return hero
+  end
+
+  local target_mode = spell.get_target_mode and spell:get_target_mode() or "hero"
+  if target_mode == "enemy" then
     local target = scaffold.target
     if target and target ~= hero and target.is_alive and target:is_alive() then
       return target
@@ -264,8 +269,27 @@ function PredictionEngine:_resolve_spell_target(scaffold, hero, enemies)
     return self:_get_first_living(enemies)
   end
 
-  if effect.type == 'global' then
-    return hero
+  if target_mode == "hero" then
+    if hero:is_alive() then
+      return hero
+    end
+    return nil
+  end
+
+  if target_mode == "any" then
+    local target = scaffold.target
+    if target and target.is_alive and target:is_alive() then
+      return target
+    end
+
+    local enemy = self:_get_first_living(enemies)
+    if enemy then
+      return enemy
+    end
+    if hero:is_alive() then
+      return hero
+    end
+    return nil
   end
 
   local target = scaffold.target

--- a/src/combat/timeline_manager.lua
+++ b/src/combat/timeline_manager.lua
@@ -186,6 +186,7 @@ function TimelineManager:insert_at(index, spell, predicted_action)
     type = "insert",
     index = index,
     spell = spell,
+    target = predicted_action and predicted_action.target or nil,
   })
   self:_recalculate_from(index)
 end
@@ -339,7 +340,11 @@ function TimelineManager:get_total_suspicion_preview()
   local total = 0
   for _, intervention in ipairs(self.interventions) do
     if intervention.spell then
-      total = total + (intervention.spell:get_suspicion_delta() or 0)
+      local delta = intervention.spell:get_suspicion_delta() or 0
+      if intervention.type == "insert" and intervention.spell.get_signed_suspicion_delta then
+        delta = intervention.spell:get_signed_suspicion_delta(intervention.target, self.hero)
+      end
+      total = total + delta
     end
   end
   return total

--- a/src/handler/combat_handler.lua
+++ b/src/handler/combat_handler.lua
@@ -28,7 +28,9 @@ local i18n = require('src.i18n.init')
 ---@field insert_selection_phase string "IDLE"|"SELECT_TARGET"|"SELECT_TIMING"
 ---@field pending_insert_spell Spell|nil
 ---@field pending_insert_target Entity|nil
----@field hovered_insert_target Enemy|nil
+---@field hovered_insert_target Entity|nil
+---@field hero_world_x number
+---@field hero_world_y number
 local CombatHandler = class('CombatHandler')
 
 function CombatHandler:initialize()
@@ -85,6 +87,8 @@ function CombatHandler:initialize()
   self.pending_insert_spell = nil
   self.pending_insert_target = nil
   self.hovered_insert_target = nil
+  self.hero_world_x = 0
+  self.hero_world_y = 0
 end
 
 function CombatHandler:set_on_combat_end(callback)
@@ -109,6 +113,11 @@ function CombatHandler:start_combat(hero, enemies, spell_book, mana_manager, sus
   self.suspicion_manager = suspicion_manager
   self.combat_log = {}
   self:_clear_insert_selection()
+
+  if self.camera then
+    self.hero_world_x = self.camera.target_x or self.camera.x or self.hero_world_x
+    self.hero_world_y = self.camera.target_y or self.camera.y or self.hero_world_y
+  end
 
   self.combat_manager:start_combat(hero, enemies)
   self.combat_manager:set_suspicion_manager(suspicion_manager)
@@ -228,6 +237,20 @@ function CombatHandler:draw_world()
       end
     end
   end
+
+  local hero = self.combat_manager:get_hero()
+  if self.insert_selection_phase == "SELECT_TARGET" and hero and self.hovered_insert_target == hero then
+    local hx, hy = self:_get_hero_world_position()
+    love.graphics.setColor(1, 0.9, 0.2, 1)
+    love.graphics.setLineWidth(3)
+    love.graphics.circle('line', hx, hy, 26)
+    love.graphics.setLineWidth(1)
+    love.graphics.polygon('fill',
+      hx, hy - 40,
+      hx - 10, hy - 60,
+      hx + 10, hy - 60)
+  end
+
   love.graphics.setColor(1, 1, 1, 1)
 end
 
@@ -383,10 +406,9 @@ function CombatHandler:_begin_insert_selection(spell)
   self.pending_insert_target = nil
   self.hovered_insert_target = nil
 
-  if self:_spell_requires_enemy_target(spell) then
-    local tm = self.combat_manager:get_turn_manager()
-    local living = tm and tm:get_living_enemies() or {}
-    if #living == 0 then
+  local target_mode = spell:get_target_mode()
+  if self:_spell_requires_target_selection(spell) then
+    if not self:_has_available_target_for_mode(target_mode) then
       self.spell_book:unreserve(spell)
       spell:unreserve(self.mana_manager)
       self:_clear_insert_selection()
@@ -404,22 +426,44 @@ end
 
 ---@param spell Spell
 ---@return boolean
-function CombatHandler:_spell_requires_enemy_target(spell)
-  local effect = spell:get_effect()
-  if not effect then return false end
-  return effect.type == "damage" or effect.type == "debuff_attack" or effect.type == "debuff_speed"
+function CombatHandler:_spell_requires_target_selection(spell)
+  local mode = spell:get_target_mode()
+  return mode == "enemy" or mode == "any"
+end
+
+---@param mode string
+---@return boolean
+function CombatHandler:_has_available_target_for_mode(mode)
+  local hero = self.combat_manager:get_hero()
+  local has_hero = hero and hero:is_alive() or false
+  local tm = self.combat_manager:get_turn_manager()
+  local living = tm and tm:get_living_enemies() or {}
+  local has_enemy = #living > 0
+
+  if mode == "enemy" then
+    return has_enemy
+  end
+  if mode == "any" then
+    return has_hero or has_enemy
+  end
+  return has_hero
 end
 
 ---@param spell Spell
 ---@return Entity|nil
 function CombatHandler:_get_default_insert_target(spell)
   local hero = self.combat_manager:get_hero()
-  local effect = spell:get_effect()
-  if effect and (effect.type == "damage" or effect.type == "debuff_attack" or effect.type == "debuff_speed") then
-    local tm = self.combat_manager:get_turn_manager()
-    local living = tm and tm:get_living_enemies() or {}
+  local tm = self.combat_manager:get_turn_manager()
+  local living = tm and tm:get_living_enemies() or {}
+  local mode = spell:get_target_mode()
+
+  if mode == "enemy" then
     return living[1]
   end
+  if mode == "any" then
+    return living[1] or (hero and hero:is_alive() and hero or nil)
+  end
+
   if hero and hero:is_alive() then
     return hero
   end
@@ -613,12 +657,24 @@ function CombatHandler:_update_insert_target_hover()
   if self.insert_selection_phase ~= "SELECT_TARGET" then
     return
   end
-  if not self.pending_insert_spell or not self:_spell_requires_enemy_target(self.pending_insert_spell) then
+  if not self.pending_insert_spell or not self:_spell_requires_target_selection(self.pending_insert_spell) then
     return
   end
 
   local mx, my = love.mouse.getPosition()
-  self.hovered_insert_target = self:_get_hovered_enemy_target(mx, my)
+  self.hovered_insert_target = self:_get_hovered_insert_target(mx, my, self.pending_insert_spell)
+end
+
+---@return number
+---@return number
+function CombatHandler:_get_hero_world_position()
+  if self.hero_world_x and self.hero_world_y then
+    return self.hero_world_x, self.hero_world_y
+  end
+  if self.camera then
+    return self.camera.target_x or self.camera.x, self.camera.target_y or self.camera.y
+  end
+  return 0, 0
 end
 
 ---@param sx number
@@ -634,29 +690,43 @@ end
 
 ---@param mx number
 ---@param my number
----@return Enemy|nil
-function CombatHandler:_get_hovered_enemy_target(mx, my)
+---@param spell Spell
+---@return Entity|nil
+function CombatHandler:_get_hovered_insert_target(mx, my, spell)
   local world_x, world_y = self:_screen_to_world(mx, my)
+  local mode = spell:get_target_mode()
+  local hero = self.combat_manager:get_hero()
   local enemies = self.combat_manager:get_enemies() or {}
-  local best_enemy = nil
+  local best_target = nil
   local best_dist2 = nil
   local hit_radius = 36
   local hit_radius2 = hit_radius * hit_radius
 
-  for i, enemy in ipairs(enemies) do
-    if enemy:is_alive() then
-      local ey = self.enemy_world_y + (i - 1) * 70
-      local dx = world_x - self.enemy_world_x
-      local dy = world_y - ey
-      local dist2 = dx * dx + dy * dy
-      if dist2 <= hit_radius2 and (not best_dist2 or dist2 < best_dist2) then
-        best_enemy = enemy
-        best_dist2 = dist2
+  local function try_target(target, tx, ty)
+    local dx = world_x - tx
+    local dy = world_y - ty
+    local dist2 = dx * dx + dy * dy
+    if dist2 <= hit_radius2 and (not best_dist2 or dist2 < best_dist2) then
+      best_target = target
+      best_dist2 = dist2
+    end
+  end
+
+  if (mode == "hero" or mode == "any") and hero and hero:is_alive() then
+    local hx, hy = self:_get_hero_world_position()
+    try_target(hero, hx, hy)
+  end
+
+  if mode == "enemy" or mode == "any" then
+    for i, enemy in ipairs(enemies) do
+      if enemy:is_alive() then
+        local ey = self.enemy_world_y + (i - 1) * 70
+        try_target(enemy, self.enemy_world_x, ey)
       end
     end
   end
 
-  return best_enemy
+  return best_target
 end
 
 --- Update gauges

--- a/src/scene/game_scene.lua
+++ b/src/scene/game_scene.lua
@@ -407,6 +407,8 @@ function GameScene:_enter_combat()
 
   -- combat_handler에 전투 데이터 전달
   self.combat_handler:start_combat(self.hero, enemies, self.spell_book, self.mana_manager, self.suspicion_manager)
+  self.combat_handler.hero_world_x = self.hero_world_x
+  self.combat_handler.hero_world_y = self.hero_world_y
 
   -- 애니메이션
   self.combat_handler.enemy_world_x = self.hero_world_x + 800

--- a/src/spell/spell.lua
+++ b/src/spell/spell.lua
@@ -6,10 +6,26 @@ local class = require('lib.middleclass')
 ---@field description string
 ---@field cost number
 ---@field suspicion_delta number
+---@field target_mode string "hero"|"enemy"|"any"
 ---@field effect SpellEffectObject
 ---@field timeline_type string "insert"|"manipulate_swap"|"manipulate_remove"|"manipulate_delay"|"manipulate_modify"|"global"
 ---@field new fun(self: Spell, data: table): Spell
 local Spell = class('Spell')
+
+---@param effect SpellEffectObject|nil
+---@return string
+local function infer_target_mode(effect)
+  if not effect then
+    return "hero"
+  end
+
+  if effect.type == "damage" or effect.type == "debuff_attack" or effect.type == "debuff_speed" then
+    -- Enemy-target spells are selectable on both sides in planning.
+    return "any"
+  end
+
+  return "hero"
+end
 
 --- Initialize a spell from a data table
 ---@param data table
@@ -20,6 +36,7 @@ function Spell:initialize(data)
   self.cost = data.cost
   self.suspicion_delta = data.suspicion_delta
   self.effect = data.effect
+  self.target_mode = data.target_mode or infer_target_mode(self.effect)
   self.timeline_type = data.timeline_type or "insert"
 end
 
@@ -46,6 +63,31 @@ end
 ---@return number
 function Spell:get_suspicion_delta()
   return self.suspicion_delta
+end
+
+---@return string
+function Spell:get_target_mode()
+  return self.target_mode
+end
+
+---@param target any
+---@param hero any
+---@return number
+function Spell:get_signed_suspicion_delta(target, hero)
+  local base = self.suspicion_delta or 0
+  if base == 0 then
+    return 0
+  end
+
+  if self.target_mode == "any" then
+    local magnitude = math.abs(base)
+    if target and hero and target == hero then
+      return -magnitude
+    end
+    return magnitude
+  end
+
+  return base
 end
 
 ---@return SpellEffectObject
@@ -84,11 +126,12 @@ end
 function Spell:execute(target, context)
   self.effect:apply(target, context)
 
-  if context.suspicion_manager then
-    if self.suspicion_delta > 0 then
-      context.suspicion_manager:add(self.suspicion_delta)
-    elseif self.suspicion_delta < 0 then
-      context.suspicion_manager:reduce(math.abs(self.suspicion_delta))
+  if context and context.suspicion_manager then
+    local delta = self:get_signed_suspicion_delta(target, context.hero)
+    if delta > 0 then
+      context.suspicion_manager:add(delta)
+    elseif delta < 0 then
+      context.suspicion_manager:reduce(math.abs(delta))
     end
   end
 end

--- a/src/ui/spell_book_overlay.lua
+++ b/src/ui/spell_book_overlay.lua
@@ -318,7 +318,11 @@ function SpellBookOverlay:_draw_spell_item(spell, index, y)
   love.graphics.print(spell:get_cost() .. " mana", SPELL_ITEM_X + 30, y + 28)
 
   local susp = spell:get_suspicion_delta()
-  if susp > 0 then
+  local target_mode = spell.get_target_mode and spell:get_target_mode() or "hero"
+  if target_mode == "any" and susp ~= 0 then
+    love.graphics.setColor(1, 0.85, 0.35, text_alpha * 0.85)
+    love.graphics.print("susp: ±" .. math.abs(susp), SPELL_ITEM_X + 120, y + 28)
+  elseif susp > 0 then
     love.graphics.setColor(1, 0.3, 0.3, text_alpha * 0.8)
     love.graphics.print("susp: +" .. susp, SPELL_ITEM_X + 120, y + 28)
   elseif susp < 0 then


### PR DESCRIPTION
﻿## 변경 사항
- insert 스펠 대상 선택 로직을 `hero/enemy/any` 모드로 확장
- `Crippling Hex` 포함 디버프 계열에서 영웅/적 모두 선택 가능하도록 수정
- 대상에 따라 의심도 증감 부호가 바뀌도록 적용(영웅 대상 감소, 적 대상 증가)
- 타임라인 재계산/의심도 프리뷰가 실제 대상 기준과 일치하도록 보정

## 검증
- `FRDY_CI_CHECK=1` 환경에서 Love2D 5초 실행 검증 통과(에러 로그 없음)
