### PR TITLE
fix(combat): 비삽입 각성 포인트 누적 시점 실행 후로 조정

### DIFF
--- a/src/handler/combat_handler.lua
+++ b/src/handler/combat_handler.lua
@@ -812,14 +812,15 @@ end
 --- Confirm planning: transition to execution
 function CombatHandler:_confirm_planning()
   local tlm = self.combat_manager:get_timeline_manager()
+  local confirmed_interventions = tlm and tlm:get_interventions() or nil
   self:_clear_insert_selection()
   self.timeline_ui:exit_insert_mode()
   self:_set_timing_focus(false)
 
   -- Manipulate/global cards don't create spell actions in execution,
   -- so apply suspicion once at confirm time.
-  if tlm and self.suspicion_manager then
-    for _, intervention in ipairs(tlm:get_interventions()) do
+  if confirmed_interventions and self.suspicion_manager then
+    for _, intervention in ipairs(confirmed_interventions) do
       if intervention.spell and intervention.type ~= "insert" then
         local delta = intervention.spell:get_suspicion_delta() or 0
         if delta > 0 then
@@ -829,10 +830,6 @@ function CombatHandler:_confirm_planning()
         end
       end
     end
-  end
-
-  if tlm and self.reward_manager and self.reward_manager.on_non_insert_spells_confirmed then
-    self.reward_manager:on_non_insert_spells_confirmed(tlm:get_interventions())
   end
 
   -- Confirm spell book (reserved → used)
@@ -848,6 +845,9 @@ function CombatHandler:_confirm_planning()
 
   -- Start execution
   self.combat_manager:start_execution()
+  if confirmed_interventions and self.reward_manager and self.reward_manager.on_non_insert_spells_confirmed then
+    self.reward_manager:on_non_insert_spells_confirmed(confirmed_interventions)
+  end
   self.execution_timer = self.execution_delay
 
   table.insert(self.combat_log, i18n.t("combat.execution_start"))

--- a/tests/unit/combat_handler_test.lua
+++ b/tests/unit/combat_handler_test.lua
@@ -1,0 +1,61 @@
+local TestHelper = require('tests.test_helper')
+local CombatHandler = require('src.handler.combat_handler')
+
+local suite = {}
+
+---@return nil
+function suite.test_non_insert_awakening_accumulates_after_execution_start()
+  local handler = CombatHandler:new()
+  local events = {}
+  local interventions = {
+    {type = "global", spell = {get_cost = function() return 40 end}},
+    {type = "insert", spell = {get_cost = function() return 20 end}},
+  }
+  local timeline_manager = {
+    interventions = interventions,
+  }
+
+  function timeline_manager:get_interventions()
+    table.insert(events, "get_interventions")
+    return self.interventions
+  end
+
+  function timeline_manager:confirm()
+    table.insert(events, "timeline_confirm")
+    self.interventions = {}
+  end
+
+  local execution_started = false
+  local received_interventions = nil
+
+  handler.combat_manager = {
+    get_timeline_manager = function()
+      return timeline_manager
+    end,
+    start_execution = function()
+      execution_started = true
+      table.insert(events, "start_execution")
+    end,
+  }
+  handler.spell_book = {
+    confirm = function()
+      table.insert(events, "spell_book_confirm")
+    end,
+  }
+  handler.suspicion_manager = nil
+  handler.reward_manager = {
+    on_non_insert_spells_confirmed = function(_, confirmed_interventions)
+      TestHelper.assert_true(execution_started, "각성 누적은 실행 시작 이후여야 합니다.")
+      received_interventions = confirmed_interventions
+      table.insert(events, "reward_confirmed")
+    end,
+  }
+
+  handler:_confirm_planning()
+
+  TestHelper.assert_equal(received_interventions, interventions, "개입 스냅샷이 전달되어야 합니다.")
+  TestHelper.assert_equal(#timeline_manager.interventions, 0, "타임라인 개입 목록은 확정 후 비워져야 합니다.")
+  TestHelper.assert_equal(table.concat(events, " > "), "get_interventions > spell_book_confirm > timeline_confirm > start_execution > reward_confirmed")
+end
+
+return suite


### PR DESCRIPTION
## 요약
- 비삽입 마법 각성 포인트 누적 호출 시점을 계획 확정 단계에서 실행 시작 직후로 이동
- `TimelineManager:confirm()` 이후에도 누락 없이 반영되도록 interventions 스냅샷 기반으로 전달
- 호출 순서 회귀를 막는 단위 테스트 추가

## 변경 파일
- `src/handler/combat_handler.lua`
- `tests/unit/combat_handler_test.lua`

## 검증
- `./scripts/run_tests.sh` 통과 (14 passed, 0 failed)
- `./scripts/check_love.sh` 통과 (exit code 0)

## 관련 이슈
- Closes #17
