### PR TITLE
feat(core): 런 시드 기반 결정론 RNG 도입

### DIFF
--- a/scripts/check_rng_usage.sh
+++ b/scripts/check_rng_usage.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+TARGETS=(
+  "$ROOT_DIR/src/map"
+  "$ROOT_DIR/src/reward"
+  "$ROOT_DIR/src/event"
+  "$ROOT_DIR/src/handler"
+  "$ROOT_DIR/src/scene"
+)
+
+if rg -n "math\\.random(seed)?\\s*\\(" "${TARGETS[@]}"; then
+  echo ""
+  echo "gameplay 경로에서 전역 math.random/math.randomseed 직접 호출이 감지되었습니다." >&2
+  echo "RNG 서비스를 통해 난수를 사용하세요." >&2
+  exit 1
+fi
+
+echo "[OK] gameplay RNG direct calls: 0"

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -12,4 +12,5 @@ else
   exit 127
 fi
 
+"$ROOT_DIR/scripts/check_rng_usage.sh"
 "$LUA_BIN" "$ROOT_DIR/tests/run.lua"

--- a/src/anim/camera.lua
+++ b/src/anim/camera.lua
@@ -1,5 +1,6 @@
 local class = require('lib.middleclass')
 local flux = require('lib.flux')
+local RNG = require('src.core.rng')
 
 ---@class Camera
 ---@field x number current camera center world X
@@ -10,11 +11,15 @@ local flux = require('lib.flux')
 ---@field shake_amount number current shake intensity
 ---@field shake_timer number remaining shake duration
 ---@field _active_tween table|nil reference to active move tween for cancellation
+---@field _shake_offset_x number
+---@field _shake_offset_y number
+---@field rng RNG
 local Camera = class('Camera')
 
 ---Initialize camera with default values
+---@param rng? RNG
 ---@return nil
-function Camera:initialize()
+function Camera:initialize(rng)
   self.x = 0
   self.y = 0
   self.target_x = 0
@@ -23,6 +28,15 @@ function Camera:initialize()
   self.shake_amount = 0
   self.shake_timer = 0
   self._active_tween = nil
+  self._shake_offset_x = 0
+  self._shake_offset_y = 0
+  self.rng = rng or RNG:new(os.time())
+end
+
+---@param rng RNG
+---@return nil
+function Camera:set_rng(rng)
+  self.rng = rng
 end
 
 ---Update camera position with smooth following and shake
@@ -39,7 +53,15 @@ function Camera:update(dt)
     if self.shake_timer <= 0 then
       self.shake_timer = 0
       self.shake_amount = 0
+      self._shake_offset_x = 0
+      self._shake_offset_y = 0
+    else
+      self._shake_offset_x = (self.rng:next_float() * 2 - 1) * self.shake_amount
+      self._shake_offset_y = (self.rng:next_float() * 2 - 1) * self.shake_amount
     end
+  else
+    self._shake_offset_x = 0
+    self._shake_offset_y = 0
   end
 end
 
@@ -99,10 +121,8 @@ function Camera:apply()
   local offset_y = -(self.y - screen_height / 2)
 
   -- Add shake offset
-  if self.shake_timer > 0 then
-    offset_x = offset_x + (math.random() * 2 - 1) * self.shake_amount
-    offset_y = offset_y + (math.random() * 2 - 1) * self.shake_amount
-  end
+  offset_x = offset_x + self._shake_offset_x
+  offset_y = offset_y + self._shake_offset_y
 
   love.graphics.push()
   love.graphics.translate(offset_x, offset_y)
@@ -125,10 +145,8 @@ function Camera:get_offset()
   local offset_y = -(self.y - screen_height / 2)
 
   -- Add shake offset if active
-  if self.shake_timer > 0 then
-    offset_x = offset_x + (math.random() * 2 - 1) * self.shake_amount
-    offset_y = offset_y + (math.random() * 2 - 1) * self.shake_amount
-  end
+  offset_x = offset_x + self._shake_offset_x
+  offset_y = offset_y + self._shake_offset_y
 
   return offset_x, offset_y
 end

--- a/src/core/rng.lua
+++ b/src/core/rng.lua
@@ -1,0 +1,181 @@
+local class = require('lib.middleclass')
+
+local MODULUS = 2147483647
+local MULTIPLIER = 48271
+local MAX_SEED = MODULUS - 1
+
+---@class RNGSnapshot
+---@field seed number
+---@field state number
+---@field draw_count number
+
+---@class RNG
+---@field _seed number
+---@field _state number
+---@field _draw_count number
+local RNG = class('RNG')
+
+---@param raw_seed number|string|nil
+---@return number
+local function normalize_seed(raw_seed)
+  local numeric = tonumber(raw_seed) or 1
+  numeric = math.floor(math.abs(numeric))
+  numeric = numeric % MAX_SEED
+  if numeric == 0 then
+    numeric = 1
+  end
+  return numeric
+end
+
+---@param raw_seed number|string|nil
+---@return number
+function RNG.static.normalize_seed(raw_seed)
+  return normalize_seed(raw_seed)
+end
+
+---@param text string|nil
+---@param base_seed number|string|nil
+---@return number
+function RNG.static.seed_from_string(text, base_seed)
+  local seed = normalize_seed(base_seed or 1)
+  local source = tostring(text or "")
+  for i = 1, #source do
+    seed = (seed * 131 + string.byte(source, i)) % MAX_SEED
+    if seed == 0 then
+      seed = 1
+    end
+  end
+  return seed
+end
+
+---@param seed number|string|nil
+---@return nil
+function RNG:initialize(seed)
+  self._seed = normalize_seed(seed)
+  self._state = self._seed
+  self._draw_count = 0
+end
+
+---@return number
+function RNG:get_seed()
+  return self._seed
+end
+
+---@return number
+function RNG:get_state()
+  return self._state
+end
+
+---@return number
+function RNG:get_draw_count()
+  return self._draw_count
+end
+
+---@return number
+function RNG:_advance()
+  self._state = (self._state * MULTIPLIER) % MODULUS
+  self._draw_count = self._draw_count + 1
+  return self._state
+end
+
+---@return number
+function RNG:next_float()
+  local state = self:_advance()
+  return (state - 1) / MAX_SEED
+end
+
+---@param min_val number
+---@param max_val number
+---@return number
+function RNG:next_int(min_val, max_val)
+  local lo = math.floor(min_val or 0)
+  local hi = math.floor(max_val or lo)
+  if hi < lo then
+    lo, hi = hi, lo
+  end
+
+  local span = (hi - lo) + 1
+  if span <= 1 then
+    self:_advance()
+    return lo
+  end
+
+  local roll = self:next_float()
+  local offset = math.floor(roll * span)
+  if offset >= span then
+    offset = span - 1
+  end
+  return lo + offset
+end
+
+---@param probability number|nil
+---@return boolean
+function RNG:chance(probability)
+  local p = tonumber(probability) or 0
+  if p < 0 then
+    p = 0
+  elseif p > 1 then
+    p = 1
+  end
+  return self:next_float() < p
+end
+
+---@generic T
+---@param list T[]
+---@return T|nil
+---@return number|nil
+function RNG:pick(list)
+  if type(list) ~= 'table' or #list == 0 then
+    return nil, nil
+  end
+  local index = self:next_int(1, #list)
+  return list[index], index
+end
+
+---@generic T
+---@param list T[]
+---@return T[]
+function RNG:shuffle(list)
+  local copied = {}
+  for i = 1, #list do
+    copied[i] = list[i]
+  end
+
+  for i = #copied, 2, -1 do
+    local j = self:next_int(1, i)
+    copied[i], copied[j] = copied[j], copied[i]
+  end
+
+  return copied
+end
+
+---@param stream_name string|nil
+---@return RNG
+function RNG:fork(stream_name)
+  local stream_seed = RNG.seed_from_string(stream_name, self._seed + self._draw_count * 37)
+  return RNG:new(stream_seed)
+end
+
+---@return RNGSnapshot
+function RNG:snapshot()
+  return {
+    seed = self._seed,
+    state = self._state,
+    draw_count = self._draw_count,
+  }
+end
+
+---@param snapshot RNGSnapshot|nil
+---@return boolean
+function RNG:restore(snapshot)
+  if type(snapshot) ~= 'table' then
+    return false
+  end
+
+  self._seed = normalize_seed(snapshot.seed or self._seed)
+  self._state = normalize_seed(snapshot.state or self._seed)
+  self._draw_count = math.max(0, math.floor(snapshot.draw_count or 0))
+  return true
+end
+
+return RNG

--- a/src/core/run_context.lua
+++ b/src/core/run_context.lua
@@ -1,0 +1,105 @@
+local class = require('lib.middleclass')
+local RNG = require('src.core.rng')
+
+---@class RunContextSnapshot
+---@field run_seed number
+---@field streams table<string, RNGSnapshot>
+
+---@class RunContext
+---@field run_seed number
+---@field _streams table<string, RNG>
+local RunContext = class('RunContext')
+
+---@param raw_seed number|string|nil
+---@return number
+function RunContext.static.normalize_seed(raw_seed)
+  return RNG.normalize_seed(raw_seed)
+end
+
+---@param run_seed number|string|nil
+---@return nil
+function RunContext:initialize(run_seed)
+  self.run_seed = RunContext.normalize_seed(run_seed)
+  self._streams = {}
+end
+
+---@return number
+function RunContext:get_run_seed()
+  return self.run_seed
+end
+
+---@param stream_name string
+---@return number
+function RunContext:_derive_stream_seed(stream_name)
+  return RNG.seed_from_string(stream_name, self.run_seed)
+end
+
+---@param stream_name string|nil
+---@return RNG
+function RunContext:get_stream(stream_name)
+  local name = tostring(stream_name or 'default')
+  local stream = self._streams[name]
+  if stream then
+    return stream
+  end
+
+  stream = RNG:new(self:_derive_stream_seed(name))
+  self._streams[name] = stream
+  return stream
+end
+
+---@param stream_name string
+---@return boolean
+function RunContext:has_stream(stream_name)
+  return self._streams[stream_name] ~= nil
+end
+
+---@return RunContextSnapshot
+function RunContext:snapshot()
+  local streams = {}
+  for name, rng in pairs(self._streams) do
+    streams[name] = rng:snapshot()
+  end
+  return {
+    run_seed = self.run_seed,
+    streams = streams,
+  }
+end
+
+---@param snapshot RunContextSnapshot|nil
+---@return boolean
+function RunContext:restore(snapshot)
+  if type(snapshot) ~= 'table' then
+    return false
+  end
+
+  self.run_seed = RunContext.normalize_seed(snapshot.run_seed or self.run_seed)
+  local previous_streams = self._streams or {}
+  local next_streams = {}
+
+  local stream_snapshots = snapshot.streams
+  if type(stream_snapshots) == 'table' then
+    for name, stream_snapshot in pairs(stream_snapshots) do
+      local stream = previous_streams[name] or RNG:new(self:_derive_stream_seed(name))
+      stream:restore(stream_snapshot)
+      next_streams[name] = stream
+    end
+  end
+
+  for name, stream in pairs(previous_streams) do
+    if not next_streams[name] then
+      local seed = self:_derive_stream_seed(name)
+      stream:restore({
+        seed = seed,
+        state = seed,
+        draw_count = 0,
+      })
+      next_streams[name] = stream
+    end
+  end
+
+  self._streams = next_streams
+  return true
+end
+
+return RunContext

--- a/src/event/event_manager.lua
+++ b/src/event/event_manager.lua
@@ -1,15 +1,26 @@
 local class = require('lib.middleclass')
 local Event = require('src.event.event')
 local Choice = require('src.event.choice')
+local RNG = require('src.core.rng')
 
 ---@class EventManager
 ---@field events table<string, Event>
 ---@field event_list Event[]
+---@field rng RNG
 local EventManager = class('EventManager')
 
-function EventManager:initialize()
+---@param rng? RNG
+---@return nil
+function EventManager:initialize(rng)
   self.events = {}
   self.event_list = {}
+  self.rng = rng or RNG:new(os.time())
+end
+
+---@param rng RNG
+---@return nil
+function EventManager:set_rng(rng)
+  self.rng = rng
 end
 
 ---@param data_table table[]
@@ -43,7 +54,8 @@ end
 ---@return Event|nil
 function EventManager:get_random_event()
   if #self.event_list == 0 then return nil end
-  return self.event_list[math.random(#self.event_list)]
+  local index = self.rng:next_int(1, #self.event_list)
+  return self.event_list[index]
 end
 
 ---@return number

--- a/src/handler/edge_select_handler.lua
+++ b/src/handler/edge_select_handler.lua
@@ -27,12 +27,14 @@
 ---@field blink_on boolean
 ---@field feedback_text string|nil
 ---@field path_control table
+---@field rng RNG
 
 local class = require('lib.middleclass')
 local EdgeSelector = require('src.ui.edge_selector')
 local Button = require('src.ui.button')
 local i18n = require('src.i18n.init')
 local path_control = require('data.interventions.path_control')
+local RNG = require('src.core.rng')
 
 local EdgeSelectHandler = class('EdgeSelectHandler')
 
@@ -42,7 +44,8 @@ local BLINK_INTERVAL = 0.45
 ---@param edges Edge[]
 ---@param on_select_callback function|nil
 ---@param context? EdgeSelectContext
-function EdgeSelectHandler:initialize(edges, on_select_callback, context)
+---@param rng? RNG
+function EdgeSelectHandler:initialize(edges, on_select_callback, context, rng)
   self.edges = edges or {}
   self.on_select_callback = on_select_callback
   self.edge_selector = nil
@@ -59,7 +62,14 @@ function EdgeSelectHandler:initialize(edges, on_select_callback, context)
   self.blink_on = true
   self.feedback_text = nil
   self.path_control = path_control
+  self.rng = rng or RNG:new(os.time())
   self:setup(self.edges, self.on_select_callback, context)
+end
+
+---@param rng RNG
+---@return nil
+function EdgeSelectHandler:set_rng(rng)
+  self.rng = rng
 end
 
 ---Activate handler
@@ -79,7 +89,7 @@ function EdgeSelectHandler:_roll_hero_choice_index()
   if #self.edges == 0 then
     return nil
   end
-  return math.random(#self.edges)
+  return self.rng:next_int(1, #self.edges)
 end
 
 ---@return boolean

--- a/src/handler/event_handler.lua
+++ b/src/handler/event_handler.lua
@@ -1,6 +1,7 @@
 local class = require('lib.middleclass')
 local Button = require('src.ui.button')
 local i18n = require('src.i18n.init')
+local RNG = require('src.core.rng')
 
 ---@class Hero
 ---@field get_mental_stage fun(self: Hero): number
@@ -31,12 +32,15 @@ local i18n = require('src.i18n.init')
 ---@field blink_timer number
 ---@field blink_on boolean
 ---@field feedback_text string|nil
+---@field rng RNG
 local EventHandler = class('EventHandler')
 
 local BLINK_INTERVAL = 0.45
 
 ---Constructor for EventHandler
-function EventHandler:initialize()
+---@param rng? RNG
+---@return nil
+function EventHandler:initialize(rng)
   self.event = nil
   self.context = nil
   self.choice_buttons = {}
@@ -55,6 +59,13 @@ function EventHandler:initialize()
   self.blink_timer = 0
   self.blink_on = true
   self.feedback_text = nil
+  self.rng = rng or RNG:new(os.time())
+end
+
+---@param rng RNG
+---@return nil
+function EventHandler:set_rng(rng)
+  self.rng = rng
 end
 
 ---Set the event end callback
@@ -72,7 +83,7 @@ function EventHandler:_roll_hero_choice()
   if count <= 0 then
     return nil
   end
-  return math.random(count)
+  return self.rng:next_int(1, count)
 end
 
 ---Start a new event

--- a/src/handler/reward_handler.lua
+++ b/src/handler/reward_handler.lua
@@ -1,6 +1,7 @@
 local class = require('lib.middleclass')
 local Button = require('src.ui.button')
 local i18n = require('src.i18n.init')
+local RNG = require('src.core.rng')
 
 ---@class Hero
 ---@field get_mental_stage fun(self: Hero): number
@@ -29,11 +30,14 @@ local i18n = require('src.i18n.init')
 ---@field feedback_text string|nil
 ---@field active boolean
 ---@field on_resolved fun(selected_option: RewardOption|nil)|nil
+---@field rng RNG
 local RewardHandler = class('RewardHandler')
 
 local BLINK_INTERVAL = 0.45
 
-function RewardHandler:initialize()
+---@param rng? RNG
+---@return nil
+function RewardHandler:initialize(rng)
   self.offer = nil
   self.hero = nil
   self.option_buttons = {}
@@ -48,6 +52,13 @@ function RewardHandler:initialize()
   self.feedback_text = nil
   self.active = false
   self.on_resolved = nil
+  self.rng = rng or RNG:new(os.time())
+end
+
+---@param rng RNG
+---@return nil
+function RewardHandler:set_rng(rng)
+  self.rng = rng
 end
 
 ---@param offer RewardOffer
@@ -96,7 +107,7 @@ function RewardHandler:_roll_hero_choice()
   if count <= 0 then
     return nil
   end
-  return math.random(count)
+  return self.rng:next_int(1, count)
 end
 
 ---@return Hero|nil

--- a/src/map/map_generator.lua
+++ b/src/map/map_generator.lua
@@ -4,9 +4,11 @@ local EventNode = require("src.map.event_node")
 local Edge = require("src.map.edge")
 local Floor = require("src.map.floor")
 local Map = require("src.map.map")
+local RNG = require("src.core.rng")
 
 ---@class MapGenerator
 ---@field _next_node_id number
+---@field rng RNG
 local MapGenerator = class("MapGenerator")
 
 local DEFAULT_MAP_HEIGHT = 1800
@@ -17,9 +19,11 @@ local DEFAULT_NODE_VERTICAL_MARGIN = 140
 local MAX_FLOOR_GENERATION_ATTEMPTS = 20
 local MAX_PAIR_CONNECTION_ATTEMPTS = 12
 
+---@param rng? RNG
 ---@return nil
-function MapGenerator:initialize()
+function MapGenerator:initialize(rng)
   self._next_node_id = 0
+  self.rng = rng or RNG:new(os.time())
 end
 
 ---@return number
@@ -31,8 +35,13 @@ end
 ---@param min_val number
 ---@param max_val number
 ---@return number
-local function rand_int(min_val, max_val)
-  return math.random(min_val, max_val)
+function MapGenerator:_rand_int(min_val, max_val)
+  return self.rng:next_int(min_val, max_val)
+end
+
+---@return number
+function MapGenerator:_rand_float()
+  return self.rng:next_float()
 end
 
 ---@param value number
@@ -171,7 +180,7 @@ end
 ---@param config table
 ---@return table<number, Node[]>, number
 function MapGenerator:_build_columns(floor, floor_index, config)
-  local num_columns = rand_int(config.columns_per_floor.min, config.columns_per_floor.max)
+  local num_columns = self:_rand_int(config.columns_per_floor.min, config.columns_per_floor.max)
   local columns = {}
   for col = 0, num_columns do
     columns[col] = {}
@@ -199,7 +208,7 @@ function MapGenerator:_generate_random_y_positions(node_count, map_height, confi
   end
 
   if node_count <= 1 then
-    local single_y = min_y + math.random() * (max_y - min_y)
+    local single_y = min_y + self:_rand_float() * (max_y - min_y)
     return {single_y}
   end
 
@@ -211,7 +220,7 @@ function MapGenerator:_generate_random_y_positions(node_count, map_height, confi
   local slack = math.max(usable_height - min_gap * (node_count - 1), 0)
 
   for idx = 1, node_count do
-    positions[idx] = math.random() * slack
+    positions[idx] = self:_rand_float() * slack
   end
 
   table.sort(positions)
@@ -241,10 +250,10 @@ function MapGenerator:_choose_middle_node_count(config, previous_count)
 
   if #candidates == 0 then
     -- Fallback for invalid config combinations.
-    return rand_int(min_count, max_count)
+    return self:_rand_int(min_count, max_count)
   end
 
-  return candidates[rand_int(1, #candidates)]
+  return candidates[self:_rand_int(1, #candidates)]
 end
 
 ---@param floor Floor
@@ -254,7 +263,7 @@ end
 ---@return nil
 function MapGenerator:_build_start_column(floor, columns, floor_index, config)
   local start_cfg = config.start_nodes_per_column or {min = 4, max = 5}
-  local node_count = rand_int(start_cfg.min, start_cfg.max)
+  local node_count = self:_rand_int(start_cfg.min, start_cfg.max)
   local map_height = self:_get_map_height(config)
   local y_positions = self:_generate_random_y_positions(node_count, map_height, config)
 
@@ -285,14 +294,14 @@ function MapGenerator:_build_middle_columns(floor, columns, floor_index, config,
     for row = 1, node_count do
       local y = y_positions[row]
       local node = nil
-      if math.random() < config.combat_ratio then
+      if self:_rand_float() < config.combat_ratio then
         local interval = math.max(1, math.floor(config.elite_hot_column_interval or 4))
         local offset = config.elite_hot_column_offset or 2
         local hot_chance = config.elite_hot_chance or 0.8
         local normal_chance = config.elite_normal_chance or 0.1
         local is_hot_column = ((col - offset) % interval) == 0
         local elite_chance = is_hot_column and hot_chance or normal_chance
-        local is_elite = math.random() < elite_chance
+        local is_elite = self:_rand_float() < elite_chance
         node = CombatNode:new(self:_generate_id(), {x = x, y = y}, floor_index, nil, false, is_elite)
       else
         node = EventNode:new(self:_generate_id(), {x = x, y = y}, floor_index, nil)
@@ -404,7 +413,7 @@ function MapGenerator:_pick_lowest_count_random(candidates, count_table)
     end
   end
 
-  return best[rand_int(1, #best)]
+  return best[self:_rand_int(1, #best)]
 end
 
 ---@param current_col Node[]
@@ -494,7 +503,7 @@ function MapGenerator:_build_regular_pair_edges(current_col, next_col, config)
 
   -- Add optional extra edges up to per-node target (max 3).
   for current_idx = 1, #current_col do
-    local desired = rand_int(config.edges_per_node.min, config.edges_per_node.max)
+    local desired = self:_rand_int(config.edges_per_node.min, config.edges_per_node.max)
     local target_out = math.min(desired, max_out)
 
     while out_count[current_idx] < target_out do

--- a/src/reward/legendary_inventory.lua
+++ b/src/reward/legendary_inventory.lua
@@ -1,4 +1,5 @@
 local class = require('lib.middleclass')
+local RNG = require('src.core.rng')
 
 ---@class LegendaryItemDefinition
 ---@field id string
@@ -10,12 +11,22 @@ local class = require('lib.middleclass')
 ---@field _owned_ids string[]
 ---@field _owned_lookup table<string, LegendaryItemDefinition>
 ---@field _reward_control_bonus number
+---@field _rng RNG
 local LegendaryInventory = class('LegendaryInventory')
 
-function LegendaryInventory:initialize()
+---@param rng? RNG
+---@return nil
+function LegendaryInventory:initialize(rng)
   self._owned_ids = {}
   self._owned_lookup = {}
   self._reward_control_bonus = 0
+  self._rng = rng or RNG:new(os.time())
+end
+
+---@param rng RNG
+---@return nil
+function LegendaryInventory:set_rng(rng)
+  self._rng = rng
 end
 
 ---@param item_def LegendaryItemDefinition
@@ -128,7 +139,7 @@ function LegendaryInventory:remove_random(context)
     return nil
   end
 
-  local index = math.random(#self._owned_ids)
+  local index = self._rng:next_int(1, #self._owned_ids)
   local item_id = self._owned_ids[index]
   return self:remove_by_id(item_id, context)
 end

--- a/src/reward/reward_manager.lua
+++ b/src/reward/reward_manager.lua
@@ -4,6 +4,7 @@ local Spell = require('src.spell.spell')
 local RewardCatalog = require('src.reward.reward_catalog')
 local DemonAwakening = require('src.reward.demon_awakening')
 local LegendaryInventory = require('src.reward.legendary_inventory')
+local RNG = require('src.core.rng')
 
 local config = require('data.rewards.config')
 
@@ -35,22 +36,34 @@ local config = require('data.rewards.config')
 ---@field demon_awakening DemonAwakening
 ---@field legendary_inventory LegendaryInventory
 ---@field reward_control_bonus_stage number
+---@field rng RNG
 local RewardManager = class('RewardManager')
 
 ---@param hero Hero
 ---@param spell_book SpellBook
 ---@param mana_manager ManaManager
 ---@param suspicion_manager SuspicionManager
-function RewardManager:initialize(hero, spell_book, mana_manager, suspicion_manager)
+---@param rng? RNG
+function RewardManager:initialize(hero, spell_book, mana_manager, suspicion_manager, rng)
   self.hero = hero
   self.spell_book = spell_book
   self.mana_manager = mana_manager
   self.suspicion_manager = suspicion_manager
   self.offer_queue = {}
   self.current_offer = nil
+  self.rng = rng or RNG:new(os.time())
   self.demon_awakening = DemonAwakening:new(config.demon_awakening)
-  self.legendary_inventory = LegendaryInventory:new()
+  self.legendary_inventory = LegendaryInventory:new(self.rng)
   self.reward_control_bonus_stage = 0
+end
+
+---@param rng RNG
+---@return nil
+function RewardManager:set_rng(rng)
+  self.rng = rng
+  if self.legendary_inventory and self.legendary_inventory.set_rng then
+    self.legendary_inventory:set_rng(rng)
+  end
 end
 
 ---@param hero Hero
@@ -130,8 +143,9 @@ end
 
 ---@param list string[]
 ---@param count number
+---@param rng RNG
 ---@return string[]
-local function pick_unique_random(list, count)
+local function pick_unique_random(list, count, rng)
   local working = {}
   for i = 1, #list do
     working[i] = list[i]
@@ -140,7 +154,7 @@ local function pick_unique_random(list, count)
   local picked = {}
   local max_pick = math.min(count, #working)
   for _ = 1, max_pick do
-    local index = math.random(#working)
+    local index = rng:next_int(1, #working)
     picked[#picked + 1] = working[index]
     table.remove(working, index)
   end
@@ -648,7 +662,7 @@ function RewardManager:_remove_owned_spell(mode, item_id)
   if #candidates == 0 then
     return false
   end
-  local index = math.random(#candidates)
+  local index = self.rng:next_int(1, #candidates)
   return self.spell_book:remove_spell(candidates[index])
 end
 
@@ -672,7 +686,7 @@ function RewardManager:_remove_owned_pattern(mode, pattern_id)
   if #removable == 0 then
     return false
   end
-  local index = math.random(#removable)
+  local index = self.rng:next_int(1, #removable)
   return self.hero:remove_action_pattern(removable[index])
 end
 
@@ -698,7 +712,7 @@ end
 ---@return RewardOption[]
 function RewardManager:_build_demon_spell_options()
   local ids = RewardCatalog.get_all_spell_ids()
-  local picked = pick_unique_random(ids, #ids)
+  local picked = pick_unique_random(ids, #ids, self.rng)
   local options = {}
 
   for _, spell_id in ipairs(picked) do
@@ -740,7 +754,7 @@ end
 ---@return RewardOption[]
 function RewardManager:_build_hero_pattern_options()
   local ids = RewardCatalog.get_all_pattern_ids()
-  local picked = pick_unique_random(ids, #ids)
+  local picked = pick_unique_random(ids, #ids, self.rng)
   local options = {}
 
   for _, pattern_id in ipairs(picked) do
@@ -789,7 +803,7 @@ function RewardManager:_build_legendary_item_options()
     return {}
   end
 
-  local picked = pick_unique_random(candidates, 3)
+  local picked = pick_unique_random(candidates, 3, self.rng)
   local options = {}
   for _, item_id in ipairs(picked) do
     local item_data = RewardCatalog.get_legendary_data(item_id)

--- a/src/scene/game_scene.lua
+++ b/src/scene/game_scene.lua
@@ -20,6 +20,7 @@ local EventManager = require('src.event.event_manager')
 local RewardManager = require('src.reward.reward_manager')
 local RewardHandler = require('src.handler.reward_handler')
 local RewardCatalog = require('src.reward.reward_catalog')
+local RunContext = require('src.core.run_context')
 local Game = require('src.core.game')
 local i18n = require('src.i18n.init')
 
@@ -40,6 +41,9 @@ local START_NODE_SELECT = "START_NODE_SELECT"
 
 ---@class GameScene : Scene
 ---@field phase string
+---@field run_seed number
+---@field run_context RunContext
+---@field enemy_rng RNG
 ---@field map Map
 ---@field current_node Node|nil
 ---@field target_node Node|nil
@@ -65,11 +69,28 @@ local START_NODE_SELECT = "START_NODE_SELECT"
 ---@field settings_overlay SettingsOverlay
 local GameScene = class('GameScene', Scene)
 
+---@return number
+function GameScene:_resolve_run_seed()
+  local env_seed = os.getenv('FRDY_RUN_SEED')
+  if env_seed and env_seed ~= '' then
+    local parsed = tonumber(env_seed)
+    if parsed then
+      return RunContext.normalize_seed(parsed)
+    end
+  end
+  return RunContext.normalize_seed(os.time())
+end
+
 function GameScene:initialize()
   Scene.initialize(self)
 
+  self.run_seed = self:_resolve_run_seed()
+  self.run_context = RunContext:new(self.run_seed)
+  local map_rng = self.run_context:get_stream('gameplay.map')
+  self.enemy_rng = self.run_context:get_stream('gameplay.enemy')
+
   -- 맵 생성
-  local generator = MapGenerator:new()
+  local generator = MapGenerator:new(map_rng)
   local config = require('data.map_configs.default_config')
   self.map = generator:generate_map(config)
 
@@ -84,7 +105,7 @@ function GameScene:initialize()
   self.hero_world_y = 360
 
   -- 카메라 생성 및 즉시 위치 설정 (초기 lerp 없이)
-  self.camera = Camera:new()
+  self.camera = Camera:new(self.run_context:get_stream('ui.camera'))
   self.camera:set_target(self.hero_world_x, self.hero_world_y)
   self.camera.x = self.hero_world_x
   self.camera.target_x = self.hero_world_x
@@ -108,10 +129,16 @@ function GameScene:initialize()
   local event_bus = Game:getInstance().event_bus
   self.mana_manager = ManaManager:new(100)
   self.suspicion_manager = SuspicionManager:new(event_bus)
-  self.reward_manager = RewardManager:new(self.hero, self.spell_book, self.mana_manager, self.suspicion_manager)
+  self.reward_manager = RewardManager:new(
+    self.hero,
+    self.spell_book,
+    self.mana_manager,
+    self.suspicion_manager,
+    self.run_context:get_stream('gameplay.reward')
+  )
 
   -- 이벤트 매니저 생성
-  self.event_manager = EventManager:new()
+  self.event_manager = EventManager:new(self.run_context:get_stream('gameplay.event'))
   self.event_manager:load_events(require('data.events.floor1_events'))
 
   -- 적 데이터 로드
@@ -140,11 +167,11 @@ function GameScene:initialize()
     self:_on_combat_ended(result)
   end)
 
-  self.event_handler = EventHandler:new()
+  self.event_handler = EventHandler:new(self.run_context:get_stream('gameplay.event_choice'))
   self.event_handler:set_on_event_end(function()
     self:_on_event_ended()
   end)
-  self.reward_handler = RewardHandler:new()
+  self.reward_handler = RewardHandler:new(self.run_context:get_stream('gameplay.reward_choice'))
 
   self.edge_select_handler = nil
 
@@ -156,6 +183,22 @@ function GameScene:initialize()
   self:_show_start_node_select(start_nodes)
 
   -- 게임 흐름 시작
+end
+
+---@return number
+function GameScene:get_run_seed()
+  return self.run_seed
+end
+
+---@return RunContextSnapshot
+function GameScene:get_rng_snapshot()
+  return self.run_context:snapshot()
+end
+
+---@param snapshot RunContextSnapshot
+---@return boolean
+function GameScene:restore_rng_snapshot(snapshot)
+  return self.run_context:restore(snapshot)
 end
 
 ---@param dt number
@@ -491,18 +534,18 @@ function GameScene:_create_enemies()
   else
     -- 일반 전투: 랜덤 1~2마리
     local enemy_keys = {"slime", "goblin", "skeleton", "wolf"}
-    local count = math.random(1, 2)
+    local count = self.enemy_rng:next_int(1, 2)
     for _ = 1, count do
-      local key = enemy_keys[math.random(#enemy_keys)]
+      local key = enemy_keys[self.enemy_rng:next_int(1, #enemy_keys)]
       local data = self.floor_enemies[key]
       table.insert(enemies, Enemy:new(data.name, data.stats, data.action_patterns))
     end
 
     if node.is_elite and node:is_elite() then
       local elite_enemies = {}
-      local elite_count = math.random(2, 3)
+      local elite_count = self.enemy_rng:next_int(2, 3)
       for _ = 1, elite_count do
-        local key = enemy_keys[math.random(#enemy_keys)]
+        local key = enemy_keys[self.enemy_rng:next_int(1, #enemy_keys)]
         local data = self.floor_enemies[key]
         local stats = {
           hp = math.max(1, math.floor((data.stats.hp or 1) * 1.4 + 0.5)),
@@ -651,7 +694,7 @@ function GameScene:_show_edge_select(edges)
       self:_on_edge_selected(edge)
     end, {
       hero = self.hero,
-    })
+    }, self.run_context:get_stream('gameplay.path_choice'))
   else
     self.edge_select_handler:setup(edges, function(edge)
       self:_on_edge_selected(edge)

--- a/tests/helpers/fixtures.lua
+++ b/tests/helpers/fixtures.lua
@@ -1,4 +1,5 @@
 local EventBus = require('src.core.event_bus')
+local RunContext = require('src.core.run_context')
 local Hero = require('src.combat.hero')
 local Spell = require('src.spell.spell')
 local SpellBook = require('src.spell.spell_book')
@@ -31,13 +32,19 @@ function Fixtures.create_spell_book(ids)
   return SpellBook:new(spells)
 end
 
+---@param run_seed? number
 ---@return RewardFixture
-function Fixtures.create_reward_fixture()
+function Fixtures.create_reward_fixture(run_seed)
   local hero = Hero:new({hp = 50, attack = 8, defense = 2, speed = 8})
   local spell_book = Fixtures.create_spell_book(starter_spell_ids)
   local mana_manager = ManaManager:new(100)
   local suspicion_manager = SuspicionManager:new(EventBus:new())
-  local reward_manager = RewardManager:new(hero, spell_book, mana_manager, suspicion_manager)
+  local reward_rng = nil
+  if run_seed ~= nil then
+    local run_context = RunContext:new(run_seed)
+    reward_rng = run_context:get_stream('gameplay.reward')
+  end
+  local reward_manager = RewardManager:new(hero, spell_book, mana_manager, suspicion_manager, reward_rng)
   return {
     hero = hero,
     spell_book = spell_book,

--- a/tests/unit/event_manager_test.lua
+++ b/tests/unit/event_manager_test.lua
@@ -1,0 +1,26 @@
+local TestHelper = require('tests.test_helper')
+local EventManager = require('src.event.event_manager')
+local RNG = require('src.core.rng')
+
+local suite = {}
+
+---@return nil
+function suite.test_same_seed_returns_same_event_sequence()
+  local event_data = require('data.events.floor1_events')
+
+  local manager_a = EventManager:new(RNG:new(1111))
+  manager_a:load_events(event_data)
+
+  local manager_b = EventManager:new(RNG:new(1111))
+  manager_b:load_events(event_data)
+
+  for _ = 1, 10 do
+    local event_a = manager_a:get_random_event()
+    local event_b = manager_b:get_random_event()
+    TestHelper.assert_true(event_a ~= nil)
+    TestHelper.assert_true(event_b ~= nil)
+    TestHelper.assert_equal(event_a:get_id(), event_b:get_id())
+  end
+end
+
+return suite

--- a/tests/unit/map_generator_test.lua
+++ b/tests/unit/map_generator_test.lua
@@ -1,5 +1,6 @@
 local TestHelper = require('tests.test_helper')
 local MapGenerator = require('src.map.map_generator')
+local RNG = require('src.core.rng')
 local default_config = require('data.map_configs.default_config')
 
 local suite = {}
@@ -17,6 +18,36 @@ local function deep_copy(value)
   return copied
 end
 
+---@param map Map
+---@return string
+local function map_signature(map)
+  local floor = map:get_current_floor()
+  local node_entries = {}
+  local edge_entries = {}
+
+  for _, node in ipairs(floor:get_nodes()) do
+    local pos = node:get_position()
+    local is_elite = node.is_elite and node:is_elite() or false
+    node_entries[#node_entries + 1] = string.format(
+      "%d|%s|%d|%.6f|%s|%s",
+      node.id,
+      node:get_type(),
+      pos.x,
+      pos.y,
+      tostring(node:is_boss()),
+      tostring(is_elite)
+    )
+  end
+
+  for _, edge in ipairs(floor:get_edges()) do
+    edge_entries[#edge_entries + 1] = string.format("%d>%d", edge:get_from_node().id, edge:get_to_node().id)
+  end
+
+  table.sort(node_entries)
+  table.sort(edge_entries)
+  return table.concat(node_entries, ",") .. "::" .. table.concat(edge_entries, ",")
+end
+
 ---@return nil
 function suite.test_elite_interval_zero_does_not_crash_map_generation()
   local config = deep_copy(default_config)
@@ -30,6 +61,19 @@ function suite.test_elite_interval_zero_does_not_crash_map_generation()
     TestHelper.assert_true(ok, tostring(map_or_err))
     TestHelper.assert_true(map_or_err ~= nil)
   end
+end
+
+---@return nil
+function suite.test_same_seed_generates_identical_map_layout()
+  local config = deep_copy(default_config)
+
+  local generator_a = MapGenerator:new(RNG:new(20260302))
+  local map_a = generator_a:generate_map(config)
+
+  local generator_b = MapGenerator:new(RNG:new(20260302))
+  local map_b = generator_b:generate_map(config)
+
+  TestHelper.assert_equal(map_signature(map_a), map_signature(map_b))
 end
 
 return suite

--- a/tests/unit/reward_manager_test.lua
+++ b/tests/unit/reward_manager_test.lua
@@ -4,6 +4,19 @@ local RewardCatalog = require('src.reward.reward_catalog')
 
 local suite = {}
 
+---@param offer RewardOffer|nil
+---@return string
+local function option_signature(offer)
+  if not offer then
+    return ""
+  end
+  local entries = {}
+  for _, option in ipairs(offer.options or {}) do
+    entries[#entries + 1] = string.format("%s:%s", option.id, option.action)
+  end
+  return table.concat(entries, ",")
+end
+
 ---@return nil
 function suite.test_enqueue_offer_ignores_non_positive_counts()
   local fixture = Fixtures.create_reward_fixture()
@@ -71,6 +84,23 @@ function suite.test_remove_owned_reward_respects_spell_minimum_holdings()
   TestHelper.assert_true(reward_manager:_add_spell("heal_heavy"))
   local removed_with_extra = reward_manager:remove_owned_reward("demon_spell", 1, "id", "heal_heavy")
   TestHelper.assert_equal(removed_with_extra, 1)
+end
+
+---@return nil
+function suite.test_same_seed_builds_same_demon_offer_options()
+  local fixture_a = Fixtures.create_reward_fixture(20260302)
+  local fixture_b = Fixtures.create_reward_fixture(20260302)
+  local reward_a = fixture_a.reward_manager
+  local reward_b = fixture_b.reward_manager
+
+  reward_a:enqueue_offer("demon_spell", "seed_test", 1)
+  reward_b:enqueue_offer("demon_spell", "seed_test", 1)
+
+  local offer_a = reward_a:peek_offer()
+  local offer_b = reward_b:peek_offer()
+  TestHelper.assert_true(offer_a ~= nil)
+  TestHelper.assert_true(offer_b ~= nil)
+  TestHelper.assert_equal(option_signature(offer_a), option_signature(offer_b))
 end
 
 return suite

--- a/tests/unit/rng_test.lua
+++ b/tests/unit/rng_test.lua
@@ -1,0 +1,54 @@
+local TestHelper = require('tests.test_helper')
+local RNG = require('src.core.rng')
+local RunContext = require('src.core.run_context')
+
+local suite = {}
+
+---@return nil
+function suite.test_same_seed_produces_same_sequence()
+  local left = RNG:new(12345)
+  local right = RNG:new(12345)
+
+  for _ = 1, 20 do
+    TestHelper.assert_equal(left:next_int(1, 100000), right:next_int(1, 100000))
+  end
+end
+
+---@return nil
+function suite.test_snapshot_restore_replays_from_saved_state()
+  local rng = RNG:new(777)
+
+  for _ = 1, 5 do
+    rng:next_int(1, 1000)
+  end
+  local snapshot = rng:snapshot()
+
+  local expected = {}
+  for i = 1, 8 do
+    expected[i] = rng:next_int(1, 1000)
+  end
+
+  TestHelper.assert_true(rng:restore(snapshot))
+  for i = 1, 8 do
+    TestHelper.assert_equal(rng:next_int(1, 1000), expected[i])
+  end
+end
+
+---@return nil
+function suite.test_run_context_stream_lookup_order_does_not_change_stream_output()
+  local context_a = RunContext:new(20260302)
+  local context_b = RunContext:new(20260302)
+
+  local map_a = context_a:get_stream('gameplay.map')
+  local reward_a = context_a:get_stream('gameplay.reward')
+
+  local reward_b = context_b:get_stream('gameplay.reward')
+  local map_b = context_b:get_stream('gameplay.map')
+
+  for _ = 1, 12 do
+    TestHelper.assert_equal(map_a:next_int(1, 100000), map_b:next_int(1, 100000))
+    TestHelper.assert_equal(reward_a:next_int(1, 100000), reward_b:next_int(1, 100000))
+  end
+end
+
+return suite


### PR DESCRIPTION
## 요약
- `run_seed` 기반 결정론 RNG 인프라(`RNG`, `RunContext`)를 도입했습니다.
- gameplay 난수를 전역 `math.random` 직접 호출에서 스트림 RNG 경유로 전환했습니다.
- UI 연출 난수(카메라 흔들림)는 별도 UI 스트림으로 분리했습니다.
- gameplay 경로의 전역 난수 직접 호출을 차단하는 검사 스크립트를 추가했습니다.

## 주요 변경
- RNG 코어 추가
  - `src/core/rng.lua`
  - `src/core/run_context.lua`
- gameplay 난수 전환
  - `src/map/map_generator.lua`
  - `src/reward/reward_manager.lua`
  - `src/reward/legendary_inventory.lua`
  - `src/event/event_manager.lua`
  - `src/handler/event_handler.lua`
  - `src/handler/reward_handler.lua`
  - `src/handler/edge_select_handler.lua`
  - `src/scene/game_scene.lua`
- UI 난수 분리
  - `src/anim/camera.lua`
- 검증/가드
  - `scripts/check_rng_usage.sh`
  - `scripts/run_tests.sh`에서 RNG 직접 호출 검사 실행

## 테스트
- `./scripts/run_tests.sh` 통과
  - `[OK] gameplay RNG direct calls: 0`
  - `19 passed, 0 failed`
- `./scripts/check_love.sh` 통과 (exit code 0)

## 관련 이슈
- Closes #14
