### PR TITLE
fix(event): EventManager load_events 중복 누적 방지

### DIFF
--- a/src/event/event_manager.lua
+++ b/src/event/event_manager.lua
@@ -25,6 +25,9 @@ end
 
 ---@param data_table table[]
 function EventManager:load_events(data_table)
+  self.events = {}
+  self.event_list = {}
+
   for _, event_data in ipairs(data_table) do
     local choices = {}
     for _, choice_data in ipairs(event_data.choices or {}) do

--- a/tests/unit/event_manager_test.lua
+++ b/tests/unit/event_manager_test.lua
@@ -23,4 +23,21 @@ function suite.test_same_seed_returns_same_event_sequence()
   end
 end
 
+---@return nil
+function suite.test_load_events_is_idempotent_for_same_dataset()
+  local event_data = require('data.events.floor1_events')
+  local manager = EventManager:new(RNG:new(2222))
+  local expected_count = #event_data
+
+  manager:load_events(event_data)
+  TestHelper.assert_equal(manager:get_event_count(), expected_count)
+
+  manager:load_events(event_data)
+  TestHelper.assert_equal(manager:get_event_count(), expected_count)
+
+  for _, event in ipairs(event_data) do
+    TestHelper.assert_true(manager:get_event(event.id) ~= nil)
+  end
+end
+
 return suite


### PR DESCRIPTION
## 변경 요약
- `EventManager:load_events()` 시작 시 `events`, `event_list`를 초기화하도록 수정했습니다.
- 동일 이벤트 데이터 재로딩 시 중복 누적/확률 편향이 발생하지 않도록 idempotent 동작을 보장합니다.

## 테스트
- `./scripts/run_tests.sh`
- `./scripts/check_love.sh`

## 관련 이슈
- Closes #22
