### PR TITLE
feat(card): 전체 대상 스펠과 타깃 규칙 정리

### DIFF
--- a/GAME_CONCEPT.md
+++ b/GAME_CONCEPT.md
@@ -69,8 +69,15 @@
   - `Spell`: 비용, 대상 모드, 의심치, 효과
   - `SpellEffect`: 실제 적용 로직
 - 대상 모드:
-  - `char_single`, `char_faction`, `char_all`
+  - `char_single`: 용사 또는 적 한 명
+  - `char_faction`: 용사 진영 전체 또는 적 진영 전체
+  - `char_all`: 용사와 모든 적 전체
   - `action_next_n`, `action_next_all`, `field`
+- 현재 전투용 타깃 스펠은 스펠별 진영 제한을 두지 않습니다.
+  - `char_single`, `char_faction` 스펠은 항상 용사/적 양쪽을 대상으로 선택 가능합니다.
+  - 의심치는 실제로 선택한 진영 기준으로 계산합니다.
+  - 용사 쪽을 고르면 의심이 감소하고, 적 쪽을 고르면 의심이 증가합니다.
+  - `char_all` 스펠은 진영 선택이 없고, 기본적으로 의심치를 발생시키지 않습니다.
 
 참고:
 

--- a/data/spells/base_spells.lua
+++ b/data/spells/base_spells.lua
@@ -156,14 +156,14 @@ return {
     suspicion_abs = 6,
     timeline_type = "insert",
     target_mode = "char_single",
-    effect = SpellEffect.hinder(5),
+    effect = SpellEffect.damage(5),
     upgrade = make_upgrade({
       patch_add("effect.amount", 1),
     })
   },
   {
     id = "weaken_foe",
-    name = "Weaken Foe",
+    name = "Sapping Chant",
     description = "Debuff a faction's attack by 2.",
     desc_key = "spell.desc.weaken_foe",
     cost = 11,
@@ -190,7 +190,7 @@ return {
     suspicion_abs = 12,
     timeline_type = "insert",
     target_mode = "char_single",
-    effect = SpellEffect.hinder(10),
+    effect = SpellEffect.damage(10),
     upgrade = make_upgrade({
       patch_add("cost", -1, 0),
       patch_add("effect.amount", 2),
@@ -208,6 +208,34 @@ return {
     effect = SpellEffect.heal(5),
     upgrade = make_upgrade({
       patch_add("effect.amount", 1),
+    })
+  },
+  {
+    id = "healing_rain",
+    name = "Healing Rain",
+    description = "Heal all characters for 10 HP.",
+    desc_key = "spell.desc.healing_rain",
+    cost = 24,
+    timeline_type = "insert",
+    target_mode = "char_all",
+    effect = SpellEffect.heal(10),
+    upgrade = make_upgrade({
+      patch_add("cost", -1, 0),
+      patch_add("effect.amount", 2),
+    })
+  },
+  {
+    id = "rain_of_ruin",
+    name = "Rain of Ruin",
+    description = "Deal 10 damage to all characters.",
+    desc_key = "spell.desc.rain_of_ruin",
+    cost = 28,
+    timeline_type = "insert",
+    target_mode = "char_all",
+    effect = SpellEffect.damage(10),
+    upgrade = make_upgrade({
+      patch_add("cost", -1, 0),
+      patch_add("effect.amount", 2),
     })
   },
   -- Insert spells: action-target variants

--- a/data/spells/starter_spell_ids.lua
+++ b/data/spells/starter_spell_ids.lua
@@ -6,6 +6,8 @@ local starter_spell_ids = {
   "haste_sigil",
   "stumble",
   "minor_heal",
+  "healing_rain",
+  "rain_of_ruin",
 }
 
 return starter_spell_ids

--- a/src/i18n/locales/en.lua
+++ b/src/i18n/locales/en.lua
@@ -74,6 +74,7 @@ return {
   ["spell.statuses"] = "Statuses",
   ["spell.keywords"] = "Keywords",
   ["spell.no_keyword"] = "No keywords",
+  ["spell.suspicion_targeted"] = "susp: hero -{value} / enemy +{value}",
   ["spell.suspicion_per_action"] = "susp: ±{value}/act",
 
   -- Spell tabs
@@ -88,9 +89,11 @@ return {
   ["spell.name.haste_sigil"] = "Haste Sigil",
   ["spell.name.crippling_hex"] = "Crippling Hex",
   ["spell.name.stumble"] = "Stumble",
-  ["spell.name.weaken_foe"] = "Weaken Foe",
+  ["spell.name.weaken_foe"] = "Sapping Chant",
   ["spell.name.dark_pact"] = "Dark Pact",
   ["spell.name.minor_heal"] = "Minor Heal",
+  ["spell.name.healing_rain"] = "Healing Rain",
+  ["spell.name.rain_of_ruin"] = "Rain of Ruin",
   ["spell.name.time_warp"] = "Time Warp",
   ["spell.name.nullify"] = "Nullify",
   ["spell.name.delay_strike"] = "Delay Strike",
@@ -108,6 +111,8 @@ return {
   ["spell.desc.weaken_foe"] = "Reduce a faction's attack by {amount}.",
   ["spell.desc.dark_pact"] = "Deal {amount} damage to target.",
   ["spell.desc.minor_heal"] = "Heal target for {amount} HP.",
+  ["spell.desc.healing_rain"] = "Heal all characters for {amount} HP.",
+  ["spell.desc.rain_of_ruin"] = "Deal {amount} damage to all characters.",
   ["spell.desc.time_warp"] = "Increase a faction's speed by {amount}.",
   ["spell.desc.nullify"] = "Block the next {count} action(s).",
   ["spell.desc.delay_strike"] = "Reduce a faction's speed by {amount}.",
@@ -118,7 +123,7 @@ return {
 
   -- Spell keywords
   ["spell.keyword.char_single.title"] = "Single",
-  ["spell.keyword.char_single.description"] = "Targets one character.",
+  ["spell.keyword.char_single.description"] = "Targets one character on either side.",
   ["spell.keyword.char_faction.title"] = "Faction",
   ["spell.keyword.char_faction.description"] = "Targets either the hero side or all enemies.",
   ["spell.keyword.char_all.title"] = "All",

--- a/src/i18n/locales/ko.lua
+++ b/src/i18n/locales/ko.lua
@@ -74,6 +74,7 @@ return {
   ["spell.statuses"] = "부여 상태",
   ["spell.keywords"] = "키워드",
   ["spell.no_keyword"] = "키워드 없음",
+  ["spell.suspicion_targeted"] = "의심: 용사 -{value} / 적 +{value}",
   ["spell.suspicion_per_action"] = "의심: ±{value}/행동",
 
   -- Spell tabs
@@ -88,9 +89,11 @@ return {
   ["spell.name.haste_sigil"] = "헤이스트 시길",
   ["spell.name.crippling_hex"] = "크리플링 헥스",
   ["spell.name.stumble"] = "스텀블",
-  ["spell.name.weaken_foe"] = "위큰 포",
+  ["spell.name.weaken_foe"] = "쇠약의 진언",
   ["spell.name.dark_pact"] = "다크 팩트",
   ["spell.name.minor_heal"] = "마이너 힐",
+  ["spell.name.healing_rain"] = "치유의 비",
+  ["spell.name.rain_of_ruin"] = "파멸의 비",
   ["spell.name.time_warp"] = "타임 워프",
   ["spell.name.nullify"] = "널리파이",
   ["spell.name.delay_strike"] = "딜레이 스트라이크",
@@ -108,6 +111,8 @@ return {
   ["spell.desc.weaken_foe"] = "선택한 진영의 공격력을 {amount} 내립니다.",
   ["spell.desc.dark_pact"] = "대상에게 {amount} 피해를 줍니다.",
   ["spell.desc.minor_heal"] = "대상을 {amount} 회복합니다.",
+  ["spell.desc.healing_rain"] = "모든 캐릭터의 체력을 {amount} 회복합니다.",
+  ["spell.desc.rain_of_ruin"] = "모든 캐릭터에게 {amount} 피해를 줍니다.",
   ["spell.desc.time_warp"] = "선택한 진영의 속도를 {amount} 올립니다.",
   ["spell.desc.nullify"] = "다음 {count}번의 행동을 차단합니다.",
   ["spell.desc.delay_strike"] = "선택한 진영의 속도를 {amount} 내립니다.",
@@ -118,7 +123,7 @@ return {
 
   -- Spell keywords
   ["spell.keyword.char_single.title"] = "개별",
-  ["spell.keyword.char_single.description"] = "한 캐릭터를 대상으로 발동합니다.",
+  ["spell.keyword.char_single.description"] = "용사 또는 적 한 명을 대상으로 발동합니다.",
   ["spell.keyword.char_faction.title"] = "진영",
   ["spell.keyword.char_faction.description"] = "용사 진영 또는 적 진영 전체를 대상으로 발동합니다.",
   ["spell.keyword.char_all.title"] = "전체",

--- a/src/spell/spell_effect.lua
+++ b/src/spell/spell_effect.lua
@@ -97,21 +97,12 @@ function SpellEffect.debuff_speed(amount)
   }
 end
 
---- Create a hinder effect (damage to hero)
+--- Legacy alias for targeted damage.
+--- Kept so older spell ids can stay stable while target rules remain side-agnostic.
 ---@param damage_amount number
 ---@return SpellEffectObject
 function SpellEffect.hinder(damage_amount)
-  return {
-    type = "hinder",
-    amount = damage_amount,
-    apply = function(self, target, context)
-      if context and context.apply_damage then
-        context.apply_damage(target, self.amount)
-      else
-        target:take_damage(self.amount)
-      end
-    end
-  }
+  return SpellEffect.damage(damage_amount)
 end
 
 --- Create a character status effect.

--- a/src/ui/spell_book_overlay.lua
+++ b/src/ui/spell_book_overlay.lua
@@ -318,9 +318,9 @@ function SpellBookOverlay:_draw_spell_item(spell, index, y)
 
   local susp = spell.get_suspicion_abs and spell:get_suspicion_abs() or math.abs(spell:get_suspicion_delta())
   local target_mode = spell.get_target_mode and spell:get_target_mode() or "char_single"
-  if susp ~= 0 and (target_mode == "char_single" or target_mode == "char_faction" or target_mode == "char_all") then
+  if susp ~= 0 and (target_mode == "char_single" or target_mode == "char_faction") then
     love.graphics.setColor(1, 0.85, 0.35, text_alpha * 0.85)
-    love.graphics.print("susp: ±" .. math.abs(susp), SPELL_ITEM_X + 120, y + 25)
+    love.graphics.print(i18n.t("spell.suspicion_targeted", {value = math.abs(susp)}), SPELL_ITEM_X + 120, y + 25)
   elseif susp ~= 0 and (target_mode == "action_next_n" or target_mode == "action_next_all") then
     love.graphics.setColor(1, 0.85, 0.35, text_alpha * 0.85)
     love.graphics.print(i18n.t("spell.suspicion_per_action", {value = math.abs(susp)}), SPELL_ITEM_X + 120, y + 25)

--- a/tests/unit/spell_targeting_test.lua
+++ b/tests/unit/spell_targeting_test.lua
@@ -1,0 +1,194 @@
+local TestHelper = require('tests.test_helper')
+local CombatHandler = require('src.handler.combat_handler')
+local Hero = require('src.combat.hero')
+local Enemy = require('src.combat.enemy')
+local Spell = require('src.spell.spell')
+local RewardCatalog = require('src.reward.reward_catalog')
+local starter_spell_ids = require('data.spells.starter_spell_ids')
+
+---@class SpellTargetingTestSuite
+local suite = {}
+
+---@return Hero
+local function create_hero()
+  return Hero:new({hp = 50, attack = 8, defense = 2, speed = 8})
+end
+
+---@return Enemy
+local function create_enemy()
+  return Enemy:new("enemy.slime", {hp = 24, attack = 6, defense = 1, speed = 7}, {
+    {type = "attack", damage_mult = 1.0},
+  })
+end
+
+---@param hero Hero
+---@param enemies Enemy[]
+---@return CombatHandler
+local function create_handler(hero, enemies)
+  local handler = CombatHandler:new()
+  local turn_manager = {
+    get_living_enemies = function()
+      return enemies
+    end,
+  }
+
+  handler.combat_manager = {
+    get_hero = function()
+      return hero
+    end,
+    get_turn_manager = function()
+      return turn_manager
+    end,
+    get_enemies = function()
+      return enemies
+    end,
+  }
+
+  return handler
+end
+
+---@return nil
+function suite.test_single_target_spells_can_target_hero_and_enemy()
+  local hero = create_hero()
+  local enemy = create_enemy()
+  local handler = create_handler(hero, {enemy})
+  local spell = Spell:new(RewardCatalog.get_spell_data("divine_strike"))
+
+  local candidates = handler:_get_single_target_candidates(spell)
+
+  TestHelper.assert_equal(#candidates, 2, "개별 타깃 스펠은 양 진영 모두 후보여야 합니다.")
+  TestHelper.assert_equal(candidates[1], hero)
+  TestHelper.assert_equal(candidates[2], enemy)
+end
+
+---@return nil
+function suite.test_faction_target_spells_can_target_hero_and_enemy_sides()
+  local hero = create_hero()
+  local enemy = create_enemy()
+  local handler = create_handler(hero, {enemy})
+
+  local sides = handler:_get_available_faction_sides()
+
+  TestHelper.assert_equal(#sides, 2, "진영 타깃 스펠은 양 진영 모두 후보여야 합니다.")
+  TestHelper.assert_equal(sides[1], "hero")
+  TestHelper.assert_equal(sides[2], "enemy")
+end
+
+---@return nil
+function suite.test_single_target_spell_suspicion_depends_on_selected_side()
+  local hero = create_hero()
+  local enemy = create_enemy()
+  local spell = Spell:new(RewardCatalog.get_spell_data("divine_strike"))
+
+  TestHelper.assert_equal(spell:get_signed_suspicion_delta(hero, hero), -6)
+  TestHelper.assert_equal(spell:get_signed_suspicion_delta(enemy, hero), 6)
+end
+
+---@return nil
+function suite.test_faction_target_spell_suspicion_depends_on_selected_side()
+  local hero = create_hero()
+  local enemy = create_enemy()
+  local spell = Spell:new(RewardCatalog.get_spell_data("weaken_foe"))
+  local hero_target = {
+    target_mode = "char_faction",
+    faction = "hero",
+    entities = {hero},
+    primary = hero,
+  }
+  local enemy_target = {
+    target_mode = "char_faction",
+    faction = "enemy",
+    entities = {enemy},
+    primary = enemy,
+  }
+
+  TestHelper.assert_equal(spell:get_signed_suspicion_delta(hero_target, hero), -3)
+  TestHelper.assert_equal(spell:get_signed_suspicion_delta(enemy_target, hero), 3)
+end
+
+---@return nil
+function suite.test_all_target_spell_targets_everyone_without_selection()
+  local hero = create_hero()
+  local enemy_a = create_enemy()
+  local enemy_b = create_enemy()
+  local handler = create_handler(hero, {enemy_a, enemy_b})
+  local spell = Spell:new(RewardCatalog.get_spell_data("healing_rain"))
+
+  TestHelper.assert_false(handler:_spell_requires_target_selection(spell), "전체 타깃 스펠은 별도 대상 선택이 없어야 합니다.")
+
+  local payload = handler:_get_default_insert_target(spell)
+
+  TestHelper.assert_true(payload ~= nil, "전체 타깃 payload가 생성되어야 합니다.")
+  TestHelper.assert_equal(payload.target_mode, "char_all")
+  TestHelper.assert_equal(#payload.entities, 3)
+  TestHelper.assert_equal(payload.entities[1], hero)
+  TestHelper.assert_equal(payload.entities[2], enemy_a)
+  TestHelper.assert_equal(payload.entities[3], enemy_b)
+end
+
+---@return nil
+function suite.test_all_target_spell_has_no_suspicion()
+  local hero = create_hero()
+  local enemy = create_enemy()
+  local spell = Spell:new(RewardCatalog.get_spell_data("healing_rain"))
+  local target = {
+    target_mode = "char_all",
+    entities = {hero, enemy},
+    primary = hero,
+  }
+
+  TestHelper.assert_equal(spell:get_signed_suspicion_delta(target, hero), 0)
+end
+
+---@return nil
+function suite.test_starter_spell_pool_includes_all_target_spells()
+  local has_healing_rain = false
+  local has_rain_of_ruin = false
+
+  for _, spell_id in ipairs(starter_spell_ids) do
+    if spell_id == "healing_rain" then
+      has_healing_rain = true
+    elseif spell_id == "rain_of_ruin" then
+      has_rain_of_ruin = true
+    end
+  end
+
+  TestHelper.assert_true(has_healing_rain, "시작 덱에 치유의 비가 포함되어야 합니다.")
+  TestHelper.assert_true(has_rain_of_ruin, "시작 덱에 파멸의 비가 포함되어야 합니다.")
+end
+
+---@return nil
+function suite.test_legacy_target_scope_faction_maps_to_char_faction()
+  local spell = Spell:new({
+    id = "legacy_faction",
+    name = "Legacy Faction",
+    cost = 1,
+    suspicion_abs = 1,
+    target_scope = "faction",
+    effect = {
+      type = "buff_attack",
+      amount = 1,
+    },
+  })
+
+  TestHelper.assert_equal(spell:get_target_mode(), "char_faction")
+end
+
+---@return nil
+function suite.test_legacy_target_mode_any_maps_to_char_single()
+  local spell = Spell:new({
+    id = "legacy_any",
+    name = "Legacy Any",
+    cost = 1,
+    suspicion_abs = 1,
+    target_mode = "any",
+    effect = {
+      type = "heal",
+      amount = 1,
+    },
+  })
+
+  TestHelper.assert_equal(spell:get_target_mode(), "char_single")
+end
+
+return suite


### PR DESCRIPTION
관련 이슈: #20

## 요약
- `char_all` 대상 기본 스펠 2종(`치유의 비`, `파멸의 비`)을 추가했습니다.
- 두 스펠을 시작 덱에도 포함되도록 반영했습니다.
- `char_all` 스펠은 의심치를 발생시키지 않는 규칙으로 정리하고, UI 프리뷰와 문서를 현재 규칙에 맞게 맞췄습니다.
- 타깃/의심 회귀 테스트를 추가했습니다.

## 변경 내용
- `data/spells/base_spells.lua`
  - `healing_rain`, `rain_of_ruin` 추가
  - 기존 타깃 정합성 정리에서 남아 있던 구형 피해 alias 흔적 보강
- `data/spells/starter_spell_ids.lua`
  - 새 `char_all` 스펠 2종을 시작 덱에 추가
- `src/spell/spell.lua`, `src/ui/spell_book_overlay.lua`
  - `char_all` 무의심 규칙 및 프리뷰 정리
- `src/i18n/locales/*.lua`
  - 신규 스펠 이름/설명 및 타깃 규칙 문구 반영
- `tests/unit/spell_targeting_test.lua`
  - `char_single`, `char_faction`, `char_all` 타깃/의심 회귀 테스트 추가
- `GAME_CONCEPT.md`
  - 현재 타깃/의심 규칙 문서화

## 검증
- `./scripts/run_tests.sh`
- `./scripts/check_love.sh`

## 문서 동기화
- `GAME_CONCEPT.md`는 갱신했습니다.
- `README.md`, `CLASS_DIAGRAM.md`는 아키텍처/실행 구조 변경이 아니라서 이번 PR에서는 변경하지 않았습니다.

## 이슈 종료 메모
- 현재 본문에는 자동 종료 키워드(`Closes #20`)를 넣지 않았습니다.
- 따라서 이 PR이 머지되어도 #20은 자동으로 닫히지 않습니다.