### PR TITLE
fix(combat): 용사 기본 행동 선택 오류 수정

### DIFF
--- a/src/combat/pattern_resolver.lua
+++ b/src/combat/pattern_resolver.lua
@@ -11,7 +11,7 @@ local PatternResolver = {}
 ---@return ActionPattern|nil
 function PatternResolver.resolve(patterns, context)
   local best = nil
-  local best_priority = -1
+  local best_priority = -math.huge
 
   for _, pattern in ipairs(patterns) do
     if pattern:can_use(context) then

--- a/tests/unit/pattern_resolver_test.lua
+++ b/tests/unit/pattern_resolver_test.lua
@@ -1,0 +1,50 @@
+local TestHelper = require('tests.test_helper')
+local Hero = require('src.combat.hero')
+local Enemy = require('src.combat.enemy')
+local PatternResolver = require('src.combat.pattern_resolver')
+local CombatManager = require('src.combat.combat_manager')
+
+local suite = {}
+
+---@return nil
+function suite.test_fallback_pattern_is_selected_when_no_other_condition_matches()
+  local hero = Hero:new({hp = 50, attack = 8, defense = 2, speed = 8})
+  local enemy = Enemy:new('Skeleton', {hp = 25, attack = 8, defense = 2, speed = 5}, {
+    {type = "attack", damage_mult = 1.0},
+  })
+
+  local pattern = PatternResolver.resolve(hero.action_patterns, {
+    actor = hero,
+    target = enemy,
+    enemies = {enemy},
+    cooldown_tracker = hero.cooldown_tracker,
+    current_turn = 1,
+  })
+
+  TestHelper.assert_true(pattern ~= nil, "기본 fallback 패턴은 선택되어야 합니다.")
+  TestHelper.assert_equal(pattern.id, "hero_attack")
+end
+
+---@return nil
+function suite.test_combat_timeline_includes_and_executes_hero_action()
+  local hero = Hero:new({hp = 50, attack = 8, defense = 2, speed = 8})
+  local enemy = Enemy:new('Skeleton', {hp = 25, attack = 8, defense = 2, speed = 5}, {
+    {type = "attack", damage_mult = 1.0},
+  })
+  local combat_manager = CombatManager:new()
+
+  combat_manager:start_combat(hero, {enemy})
+
+  local timeline = combat_manager:get_timeline_manager():get_timeline()
+  TestHelper.assert_equal(#timeline, 2, "용사와 적 행동이 모두 타임라인에 있어야 합니다.")
+  TestHelper.assert_equal(timeline[1]:get_source_type(), "hero")
+
+  combat_manager:start_execution()
+  local first_action = combat_manager:execute_next_action()
+
+  TestHelper.assert_true(first_action ~= nil, "첫 번째 실행 액션이 존재해야 합니다.")
+  TestHelper.assert_equal(first_action:get_source_type(), "hero")
+  TestHelper.assert_equal(enemy:get_hp(), 19, "용사 기본 공격이 실제로 적 체력을 깎아야 합니다.")
+end
+
+return suite


### PR DESCRIPTION
## 요약
- fallback 패턴 비교 기준을 `-math.huge`로 조정해 기본 공격이 선택되도록 수정
- 용사 행동이 타임라인에 포함되고 실제 실행되는 회귀 테스트 추가

## 원인
기본 공격 패턴이 `fallback` 조건인데, `PatternResolver`의 초기 비교 기준값이 `-1`이라 `priority - 1000` 처리된 fallback 패턴이 항상 탈락하고 있었습니다.

## 검증
- `./scripts/run_tests.sh`
- `./scripts/check_love.sh`

## 문서
게임 설계/아키텍처/용어 변경이 없는 전투 버그 수정이어서 `GAME_CONCEPT.md`, `CLASS_DIAGRAM.md`, `README.md` 갱신은 불필요합니다.

Closes #36