### PR TITLE
fix(combat): 방어 UI와 지속 턴 보정

### DIFF
--- a/src/combat/combat_manager.lua
+++ b/src/combat/combat_manager.lua
@@ -18,7 +18,7 @@ local StatusContainer = require('src.combat.status_container')
 ---@field _suspicion_manager SuspicionManager|nil
 ---@field _demon_awakening DemonAwakening|nil
 ---@field field_status_container StatusContainer|nil
----@field _temp_defense_bonuses table<Entity, number>
+---@field _temp_defense_bonuses table<Entity, {amount: number, expires_after_turn: number}[]>
 local CombatManager = class('CombatManager')
 
 function CombatManager:initialize()
@@ -40,6 +40,7 @@ end
 ---@param hero Hero
 ---@param enemies Enemy[]
 function CombatManager:start_combat(hero, enemies)
+  self:_clear_temp_defense_bonuses()
   self.hero = hero
   self.enemies = enemies
   self._temp_defense_bonuses = {}
@@ -236,6 +237,14 @@ function CombatManager:_consume_action_statuses(action_ctx, source_entity)
   end
 end
 
+---@return number
+function CombatManager:_get_turn_count()
+  if self.turn_manager and self.turn_manager.get_turn_count then
+    return self.turn_manager:get_turn_count()
+  end
+  return 0
+end
+
 ---@param actor Entity|nil
 ---@param bonus number
 ---@return nil
@@ -248,14 +257,72 @@ function CombatManager:_apply_temp_defense_bonus(actor, bonus)
     return
   end
   actor.defense = (actor.defense or 0) + amount
-  self._temp_defense_bonuses[actor] = (self._temp_defense_bonuses[actor] or 0) + amount
+  local expires_after_turn = self:_get_turn_count() + 1
+  local entries = self._temp_defense_bonuses[actor]
+  if not entries then
+    entries = {}
+    self._temp_defense_bonuses[actor] = entries
+  end
+  entries[#entries + 1] = {
+    amount = amount,
+    expires_after_turn = expires_after_turn,
+  }
+end
+
+---@param actor Entity|nil
+---@return number
+function CombatManager:get_temp_defense_bonus(actor)
+  if not actor or type(actor) ~= "table" then
+    return 0
+  end
+  local total = 0
+  for _, entry in ipairs(self._temp_defense_bonuses[actor] or {}) do
+    total = total + math.max(0, math.floor(entry.amount or 0))
+  end
+  return total
+end
+
+---@param current_turn number
+---@return nil
+function CombatManager:_clear_expired_temp_defense_bonuses(current_turn)
+  local turn = math.max(0, math.floor(current_turn or 0))
+  for actor, entries in pairs(self._temp_defense_bonuses or {}) do
+    local expired_total = 0
+    local kept_entries = {}
+    for _, entry in ipairs(entries or {}) do
+      local amount = math.max(0, math.floor(entry.amount or 0))
+      local expires_after_turn = math.max(0, math.floor(entry.expires_after_turn or 0))
+      if amount > 0 and expires_after_turn <= turn then
+        expired_total = expired_total + amount
+      elseif amount > 0 then
+        kept_entries[#kept_entries + 1] = {
+          amount = amount,
+          expires_after_turn = expires_after_turn,
+        }
+      end
+    end
+
+    if expired_total > 0 and actor and type(actor) == "table" and type(actor.defense) == "number" then
+      actor.defense = math.max(0, actor.defense - expired_total)
+    end
+
+    if #kept_entries > 0 then
+      self._temp_defense_bonuses[actor] = kept_entries
+    else
+      self._temp_defense_bonuses[actor] = nil
+    end
+  end
 end
 
 ---@return nil
 function CombatManager:_clear_temp_defense_bonuses()
-  for actor, bonus in pairs(self._temp_defense_bonuses or {}) do
+  for actor, entries in pairs(self._temp_defense_bonuses or {}) do
+    local total = 0
+    for _, entry in ipairs(entries or {}) do
+      total = total + math.max(0, math.floor(entry.amount or 0))
+    end
     if actor and type(actor) == "table" and type(actor.defense) == "number" then
-      actor.defense = math.max(0, actor.defense - bonus)
+      actor.defense = math.max(0, actor.defense - total)
     end
   end
   self._temp_defense_bonuses = {}
@@ -408,7 +475,7 @@ end
 
 --- Start next planning phase
 function CombatManager:next_planning()
-  self:_clear_temp_defense_bonuses()
+  self:_clear_expired_temp_defense_bonuses(self:_get_turn_count())
   self:_tick_status_turns()
   self.turn_manager:next_planning()
   if self.hero and self.hero.set_current_turn then

--- a/src/handler/combat_handler.lua
+++ b/src/handler/combat_handler.lua
@@ -306,6 +306,54 @@ function CombatHandler:_draw_hero_world_gauge()
   self.hero_gauge.x = hx - self.hero_gauge.width * 0.5
   self.hero_gauge.y = hy - 54
   self.hero_gauge:draw()
+  self:_draw_defense_badge(self.hero_gauge, hero)
+end
+
+---@param gauge Gauge
+---@param entity Entity|nil
+---@return nil
+function CombatHandler:_draw_defense_badge(gauge, entity)
+  if not gauge or not entity or not entity.is_alive or not entity:is_alive() then
+    return
+  end
+
+  local defense = entity.get_defense and entity:get_defense() or 0
+  if defense <= 0 then
+    return
+  end
+
+  local bonus = 0
+  if self.combat_manager and self.combat_manager.get_temp_defense_bonus then
+    bonus = self.combat_manager:get_temp_defense_bonus(entity)
+  end
+
+  local label = i18n.t("combat.defense_badge", {
+    value = math.max(0, math.floor(defense)),
+  })
+  local font = love.graphics.getFont()
+  local badge_h = gauge.height
+  local padding_x = 10
+  local badge_w = math.max(62, font:getWidth(label) + padding_x * 2)
+  local badge_x = gauge.x + gauge.width + 8
+  local badge_y = gauge.y
+
+  if bonus > 0 then
+    love.graphics.setColor(0.18, 0.42, 0.9, 0.95)
+  else
+    love.graphics.setColor(0.16, 0.18, 0.26, 0.92)
+  end
+  love.graphics.rectangle("fill", badge_x, badge_y, badge_w, badge_h, 4, 4)
+
+  if bonus > 0 then
+    love.graphics.setColor(0.72, 0.88, 1, 1)
+  else
+    love.graphics.setColor(0.75, 0.8, 0.9, 1)
+  end
+  love.graphics.rectangle("line", badge_x, badge_y, badge_w, badge_h, 4, 4)
+
+  love.graphics.setColor(1, 1, 1, 1)
+  local text_y = badge_y + (badge_h - font:getHeight()) * 0.5 - 1
+  love.graphics.print(label, badge_x + padding_x, text_y)
 end
 
 function CombatHandler:draw_ui()
@@ -348,8 +396,10 @@ function CombatHandler:draw_ui()
   end
 
   -- Gauges
-  for _, g in ipairs(self.enemy_gauges) do
+  local enemies = self.combat_manager:get_enemies() or {}
+  for i, g in ipairs(self.enemy_gauges) do
     g:draw()
+    self:_draw_defense_badge(g, enemies[i])
   end
 
   love.graphics.pop()

--- a/src/i18n/locales/en.lua
+++ b/src/i18n/locales/en.lua
@@ -55,6 +55,7 @@ return {
   ["combat.no_valid_target"] = "No valid target: cancelled [{spell}] placement",
   ["combat.manipulate_applied"] = "[{spell}] manipulation applied!",
   ["combat.global_applied"] = "[{spell}] global effect applied!",
+  ["combat.defense_badge"] = "DEF {value}",
   ["combat.floor_cleared"] = "Floor cleared!",
   ["combat.defeat"] = "Defeat! Game Over",
 

--- a/src/i18n/locales/ko.lua
+++ b/src/i18n/locales/ko.lua
@@ -55,6 +55,7 @@ return {
   ["combat.no_valid_target"] = "유효한 대상이 없어 [{spell}] 배치를 취소했습니다",
   ["combat.manipulate_applied"] = "[{spell}] 조작 적용!",
   ["combat.global_applied"] = "[{spell}] 전역 효과 적용!",
+  ["combat.defense_badge"] = "방어 {value}",
   ["combat.floor_cleared"] = "층 클리어!",
   ["combat.defeat"] = "패배! 게임 오버",
 

--- a/tests/unit/combat_manager_test.lua
+++ b/tests/unit/combat_manager_test.lua
@@ -1,0 +1,62 @@
+local TestHelper = require("tests.test_helper")
+local CombatManager = require("src.combat.combat_manager")
+local Hero = require("src.combat.hero")
+local Enemy = require("src.combat.enemy")
+
+local suite = {}
+
+---@return CombatManager, Hero, Enemy
+local function create_fixture()
+  local combat_manager = CombatManager:new()
+  local hero = Hero:new({hp = 50, attack = 8, defense = 2, speed = 8})
+  local enemy = Enemy:new("enemy.slime", {
+    hp = 24,
+    attack = 6,
+    defense = 1,
+    speed = 6,
+  }, {
+    {type = "attack", damage_mult = 1.0},
+  })
+  combat_manager:start_combat(hero, {enemy})
+  return combat_manager, hero, enemy
+end
+
+---@return nil
+function suite.test_temp_defense_bonus_lasts_through_next_turn()
+  local combat_manager, hero = create_fixture()
+
+  combat_manager:_apply_temp_defense_bonus(hero, 3)
+
+  TestHelper.assert_equal(hero:get_defense(), 5, "방어 직후에는 즉시 방어도가 올라야 합니다.")
+  TestHelper.assert_equal(combat_manager:get_temp_defense_bonus(hero), 3, "임시 방어도 합계가 추적되어야 합니다.")
+
+  combat_manager:next_planning()
+  TestHelper.assert_equal(hero:get_defense(), 5, "다음 턴 계획 단계에서도 방어도가 유지되어야 합니다.")
+  TestHelper.assert_equal(combat_manager:get_temp_defense_bonus(hero), 3, "다음 턴 시작 전에는 임시 방어가 남아 있어야 합니다.")
+
+  combat_manager:next_planning()
+  TestHelper.assert_equal(hero:get_defense(), 2, "한 턴을 지난 뒤에는 임시 방어가 해제되어야 합니다.")
+  TestHelper.assert_equal(combat_manager:get_temp_defense_bonus(hero), 0, "만료된 임시 방어는 추적 목록에서도 제거되어야 합니다.")
+end
+
+---@return nil
+function suite.test_temp_defense_bonus_expires_per_stack()
+  local combat_manager, hero = create_fixture()
+
+  combat_manager:_apply_temp_defense_bonus(hero, 3)
+  combat_manager:next_planning()
+  combat_manager:_apply_temp_defense_bonus(hero, 2)
+
+  TestHelper.assert_equal(hero:get_defense(), 7, "연속 방어는 누적 적용되어야 합니다.")
+  TestHelper.assert_equal(combat_manager:get_temp_defense_bonus(hero), 5, "누적 임시 방어 합계가 반영되어야 합니다.")
+
+  combat_manager:next_planning()
+  TestHelper.assert_equal(hero:get_defense(), 4, "더 먼저 건 방어만 먼저 만료되어야 합니다.")
+  TestHelper.assert_equal(combat_manager:get_temp_defense_bonus(hero), 2, "남은 스택만 유지되어야 합니다.")
+
+  combat_manager:next_planning()
+  TestHelper.assert_equal(hero:get_defense(), 2, "마지막 임시 방어도 만료되면 기본 방어도로 돌아와야 합니다.")
+  TestHelper.assert_equal(combat_manager:get_temp_defense_bonus(hero), 0, "모든 임시 방어 스택이 정리되어야 합니다.")
+end
+
+return suite


### PR DESCRIPTION
## 요약
- 전투 체력바 옆에 현재 방어도를 보여주는 배지를 추가했습니다.
- 임시 방어도가 다음 턴 실행까지 유지되도록 만료 시점을 조정했습니다.
- 연속 방어 스택 만료를 검증하는 테스트를 추가했습니다.

## 검증
- `./scripts/run_tests.sh`
- `./scripts/check_love.sh`

## 문서
- 문서 갱신 불필요: 전투 UI와 임시 방어 지속 규칙의 구현 상세만 조정했습니다.