### PR TITLE
test: 비전투 선택 개입 핸들러 회귀 테스트 보강

### DIFF
--- a/tests/unit/edge_select_handler_test.lua
+++ b/tests/unit/edge_select_handler_test.lua
@@ -180,4 +180,77 @@ function suite.test_confirm_selection_applies_intervention_before_callback_accep
   TestHelper.assert_equal(mental_load_increase_count, 2)
 end
 
+function suite.test_setup_rolls_deterministic_hero_choice_from_rng()
+  local EdgeSelectHandler = require('src.handler.edge_select_handler')
+  local rng_calls = {}
+  local hero = {
+    can_be_controlled = function()
+      return true
+    end,
+    increase_mental_load = function()
+      error('increase_mental_load should not be called')
+    end,
+    get_mental_stage = function()
+      return 0
+    end,
+    get_max_mental_stage = function()
+      return 5
+    end,
+  }
+  local edges = {
+    {get_to_node = function() return {get_type = function() return 'combat' end} end},
+    {get_to_node = function() return {get_type = function() return 'event' end} end},
+    {get_to_node = function() return {get_type = function() return 'event' end} end},
+  }
+  local handler = EdgeSelectHandler:new(edges, function() end, {
+    hero = hero,
+  }, {
+    next_int = function(_, min_value, max_value)
+      rng_calls[#rng_calls + 1] = {min_value = min_value, max_value = max_value}
+      return 3
+    end,
+  })
+
+  TestHelper.assert_equal(#rng_calls, 1)
+  TestHelper.assert_equal(rng_calls[1].min_value, 1)
+  TestHelper.assert_equal(rng_calls[1].max_value, 3)
+  TestHelper.assert_equal(handler.hero_choice_index, 3)
+  TestHelper.assert_equal(handler.selected_index, 3)
+end
+
+function suite.test_on_edge_clicked_blocks_intervention_when_mental_limit_exceeded()
+  local EdgeSelectHandler = require('src.handler.edge_select_handler')
+  local hero = {
+    can_be_controlled = function()
+      return false
+    end,
+    increase_mental_load = function()
+      error('increase_mental_load should not be called')
+    end,
+    get_mental_stage = function()
+      return 4
+    end,
+    get_max_mental_stage = function()
+      return 5
+    end,
+  }
+  local edges = {
+    {get_to_node = function() return {get_type = function() return 'combat' end} end},
+    {get_to_node = function() return {get_type = function() return 'event' end} end},
+  }
+  local handler = EdgeSelectHandler:new(edges, function() end, {
+    hero = hero,
+  }, {
+    next_int = function()
+      return 1
+    end,
+  })
+
+  handler:_on_edge_clicked(edges[2], 2)
+
+  TestHelper.assert_equal(handler.selected_index, 1)
+  TestHelper.assert_equal(handler.feedback_text, 'control.blocked_by_mental')
+  TestHelper.assert_true(handler.locked_indices[2])
+end
+
 return suite

--- a/tests/unit/event_handler_test.lua
+++ b/tests/unit/event_handler_test.lua
@@ -1,0 +1,205 @@
+local TestHelper = require('tests.test_helper')
+
+local suite = {}
+
+local original_button_module = nil
+local original_i18n_module = nil
+local original_rng_module = nil
+
+function suite.before_each()
+  package.loaded['src.handler.event_handler'] = nil
+  original_button_module = package.loaded['src.ui.button']
+  original_i18n_module = package.loaded['src.i18n.init']
+  original_rng_module = package.loaded['src.core.rng']
+
+  package.loaded['src.ui.button'] = {
+    new = function()
+      return {
+        set_on_click = function(self, callback)
+          self.on_click = callback
+        end,
+        update = function() end,
+        draw = function() end,
+        hit_test = function()
+          return false
+        end,
+        mousepressed = function() end,
+      }
+    end,
+  }
+
+  package.loaded['src.i18n.init'] = {
+    t = function(key)
+      return key
+    end,
+  }
+
+  package.loaded['src.core.rng'] = {
+    new = function()
+      return {
+        next_int = function()
+          return 1
+        end,
+      }
+    end,
+  }
+end
+
+function suite.after_each()
+  package.loaded['src.handler.event_handler'] = nil
+  package.loaded['src.ui.button'] = original_button_module
+  package.loaded['src.i18n.init'] = original_i18n_module
+  package.loaded['src.core.rng'] = original_rng_module
+end
+
+---@param choice_count number
+---@param apply_hook? fun(choice_index: number, context: table)
+---@return table
+local function create_event(choice_count, apply_hook)
+  local choices = {}
+  for index = 1, choice_count do
+    choices[index] = {
+      get_text = function()
+        return 'choice-' .. index
+      end,
+      apply = function(_, context)
+        if apply_hook then
+          apply_hook(index, context)
+        end
+      end,
+    }
+  end
+
+  return {
+    get_choice_count = function()
+      return choice_count
+    end,
+    get_choices = function()
+      return choices
+    end,
+    get_intervention_max_mental_stage = function()
+      return 3
+    end,
+    get_intervention_mental_increase = function()
+      return 2
+    end,
+  }
+end
+
+---@return nil
+function suite.test_start_event_rolls_deterministic_hero_choice_from_rng()
+  local EventHandler = require('src.handler.event_handler')
+  local rng_calls = {}
+  local rng = {
+    next_int = function(_, min_value, max_value)
+      rng_calls[#rng_calls + 1] = {min_value = min_value, max_value = max_value}
+      return 2
+    end,
+  }
+  local handler = EventHandler:new(rng)
+  local event = create_event(3)
+
+  handler:start_event(event, {hero = nil})
+
+  TestHelper.assert_equal(#rng_calls, 1)
+  TestHelper.assert_equal(rng_calls[1].min_value, 1)
+  TestHelper.assert_equal(rng_calls[1].max_value, 3)
+  TestHelper.assert_equal(handler.hero_choice_index, 2)
+  TestHelper.assert_equal(handler.selected_choice_index, 2)
+  TestHelper.assert_equal(#handler.choice_buttons, 3)
+end
+
+---@return nil
+function suite.test_on_choice_clicked_blocks_intervention_above_mental_limit()
+  local EventHandler = require('src.handler.event_handler')
+  local hero = {
+    can_be_controlled = function()
+      return false
+    end,
+    get_mental_stage = function()
+      return 4
+    end,
+    get_max_mental_stage = function()
+      return 5
+    end,
+    increase_mental_load = function()
+      error('increase_mental_load should not be called')
+    end,
+  }
+  local handler = EventHandler:new({
+    next_int = function()
+      return 1
+    end,
+  })
+  local event = create_event(2)
+
+  handler:start_event(event, {hero = hero})
+  handler:_on_choice_clicked(2)
+
+  TestHelper.assert_equal(handler.selected_choice_index, 1)
+  TestHelper.assert_equal(handler.feedback_text, 'control.blocked_by_mental')
+end
+
+---@return nil
+function suite.test_confirm_selected_choice_applies_mental_load_before_choice_and_callback()
+  local EventHandler = require('src.handler.event_handler')
+  local callback_order = {}
+  local applied_choice_index = nil
+  local applied_context = nil
+  local mental_load = 0
+  local mental_load_during_apply = nil
+  local mental_load_during_callback = nil
+  local hero = {
+    can_be_controlled = function()
+      return true
+    end,
+    increase_mental_load = function(_, amount)
+      mental_load = mental_load + amount
+      return mental_load
+    end,
+    get_mental_load = function()
+      return mental_load
+    end,
+    get_mental_stage = function()
+      return 0
+    end,
+    get_max_mental_stage = function()
+      return 5
+    end,
+  }
+  local event = create_event(2, function(choice_index, context)
+    callback_order[#callback_order + 1] = 'apply'
+    applied_choice_index = choice_index
+    applied_context = context
+    mental_load_during_apply = context.hero:get_mental_load()
+  end)
+  local handler = EventHandler:new({
+    next_int = function()
+      return 1
+    end,
+  })
+
+  handler:set_on_event_end(function()
+    callback_order[#callback_order + 1] = 'event_end'
+    mental_load_during_callback = hero:get_mental_load()
+  end)
+
+  handler:start_event(event, {
+    hero = hero,
+    marker = 'context',
+  })
+  handler.selected_choice_index = 2
+  handler.hero_choice_index = 1
+
+  handler:_confirm_selected_choice()
+
+  TestHelper.assert_equal(applied_choice_index, 2)
+  TestHelper.assert_equal(applied_context.marker, 'context')
+  TestHelper.assert_equal(mental_load, 2)
+  TestHelper.assert_equal(mental_load_during_apply, 2)
+  TestHelper.assert_equal(mental_load_during_callback, 2)
+  TestHelper.assert_equal(callback_order[1], 'apply')
+  TestHelper.assert_equal(callback_order[2], 'event_end')
+end
+
+return suite

--- a/tests/unit/reward_handler_test.lua
+++ b/tests/unit/reward_handler_test.lua
@@ -1,0 +1,179 @@
+local TestHelper = require('tests.test_helper')
+
+local suite = {}
+
+local original_button_module = nil
+local original_i18n_module = nil
+local original_rng_module = nil
+
+function suite.before_each()
+  package.loaded['src.handler.reward_handler'] = nil
+  original_button_module = package.loaded['src.ui.button']
+  original_i18n_module = package.loaded['src.i18n.init']
+  original_rng_module = package.loaded['src.core.rng']
+
+  package.loaded['src.ui.button'] = {
+    new = function()
+      return {
+        set_on_click = function(self, callback)
+          self.on_click = callback
+        end,
+        update = function() end,
+        draw = function() end,
+        hit_test = function()
+          return false
+        end,
+        mousepressed = function() end,
+      }
+    end,
+  }
+
+  package.loaded['src.i18n.init'] = {
+    t = function(key)
+      return key
+    end,
+  }
+
+  package.loaded['src.core.rng'] = {
+    new = function()
+      return {
+        next_int = function()
+          return 1
+        end,
+      }
+    end,
+  }
+end
+
+function suite.after_each()
+  package.loaded['src.handler.reward_handler'] = nil
+  package.loaded['src.ui.button'] = original_button_module
+  package.loaded['src.i18n.init'] = original_i18n_module
+  package.loaded['src.core.rng'] = original_rng_module
+end
+
+---@param option_count number
+---@return table
+local function create_offer(option_count)
+  local options = {}
+  for index = 1, option_count do
+    options[index] = {
+      display_text = 'option-' .. index,
+      description = 'desc-' .. index,
+    }
+  end
+
+  return {
+    title_key = 'reward.title',
+    options = options,
+    control = {
+      max_stage = 3,
+      mental_increase = 0.25,
+    },
+  }
+end
+
+---@return nil
+function suite.test_start_offer_rolls_deterministic_hero_choice_from_rng()
+  local RewardHandler = require('src.handler.reward_handler')
+  local rng_calls = {}
+  local rng = {
+    next_int = function(_, min_value, max_value)
+      rng_calls[#rng_calls + 1] = {min_value = min_value, max_value = max_value}
+      return 2
+    end,
+  }
+  local handler = RewardHandler:new(rng)
+  local offer = create_offer(3)
+
+  handler:start_offer(offer, {hero = nil}, function() end)
+
+  TestHelper.assert_equal(#rng_calls, 1)
+  TestHelper.assert_equal(rng_calls[1].min_value, 1)
+  TestHelper.assert_equal(rng_calls[1].max_value, 3)
+  TestHelper.assert_equal(handler.hero_choice_index, 2)
+  TestHelper.assert_equal(handler.selected_choice_index, 2)
+  TestHelper.assert_equal(#handler.option_buttons, 3)
+  TestHelper.assert_true(handler.active)
+end
+
+---@return nil
+function suite.test_on_choice_clicked_blocks_intervention_above_mental_limit()
+  local RewardHandler = require('src.handler.reward_handler')
+  local hero = {
+    can_be_controlled = function()
+      return false
+    end,
+    get_mental_stage = function()
+      return 4
+    end,
+    get_max_mental_stage = function()
+      return 5
+    end,
+    increase_mental_load = function()
+      error('increase_mental_load should not be called')
+    end,
+  }
+  local handler = RewardHandler:new({
+    next_int = function()
+      return 1
+    end,
+  })
+  local offer = create_offer(2)
+
+  handler:start_offer(offer, {hero = hero}, function() end)
+  handler:_on_choice_clicked(2)
+
+  TestHelper.assert_equal(handler.selected_choice_index, 1)
+  TestHelper.assert_equal(handler.feedback_text, 'control.blocked_by_mental')
+end
+
+---@return nil
+function suite.test_confirm_selected_choice_applies_mental_load_before_callback_and_passes_option()
+  local RewardHandler = require('src.handler.reward_handler')
+  local callback_option = nil
+  local callback_mental_load = nil
+  local mental_load = 0
+  local hero = {
+    can_be_controlled = function()
+      return true
+    end,
+    increase_mental_load = function(_, amount)
+      mental_load = mental_load + amount
+      return mental_load
+    end,
+    get_mental_load = function()
+      return mental_load
+    end,
+    get_mental_stage = function()
+      return 0
+    end,
+    get_max_mental_stage = function()
+      return 5
+    end,
+  }
+  local handler = RewardHandler:new({
+    next_int = function()
+      return 1
+    end,
+  })
+  local offer = create_offer(2)
+
+  handler:start_offer(offer, {hero = hero}, function(selected_option)
+    callback_option = selected_option
+    callback_mental_load = hero:get_mental_load()
+  end)
+  handler.selected_choice_index = 2
+  handler.hero_choice_index = 1
+
+  handler:_confirm_selected_choice()
+
+  TestHelper.assert_equal(callback_option, offer.options[2])
+  TestHelper.assert_equal(callback_mental_load, 0.25)
+  TestHelper.assert_equal(mental_load, 0.25)
+  TestHelper.assert_false(handler.active)
+  TestHelper.assert_equal(handler.offer, nil)
+  TestHelper.assert_equal(#handler.option_buttons, 0)
+end
+
+return suite


### PR DESCRIPTION
## 변경 내용
- `EventHandler` 단위 테스트를 추가해 예상 선택 RNG, 정신 단계 초과 차단, 개입 확정 시 정신 부하 적용 순서를 검증했습니다.
- `RewardHandler` 단위 테스트를 추가해 예상 선택 RNG, 정신 단계 초과 차단, 확정 콜백으로 선택 결과 전달을 검증했습니다.
- 기존 `EdgeSelectHandler` 테스트에 결정론적 예상 선택과 정신 단계 초과 차단 케이스를 보강했습니다.
- 이슈 본문과 달리 `EdgeSelectHandler` 기본 회귀 테스트는 이미 존재해서, 현재 코드베이스 기준 부족한 범위만 확장했습니다.

## 검증
- `./scripts/run_tests.sh`
- `./scripts/check_love.sh`

## 관련 이슈
- Closes #33

## 문서 동기화
- 문서 업데이트 불필요: 런타임 동작 변경 없이 회귀 테스트만 보강한 PR입니다.