### PR TITLE
fix(core): 자동화 런 시드 기본값 고정

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ love .
 ./scripts/check_love.sh
 ```
 
-- `run_tests.sh`: 단위/통합 테스트 실행
-- `check_love.sh`: 기본적으로 `FRDY_CI_CHECK=1` 기반 Love2D 무팝업 실행 검증을 수행하고, 디스플레이가 없는 자동화 환경에서는 Lua headless bootstrap smoke check로 자동 전환
+- `run_tests.sh`: 단위/통합 테스트를 실행하고, `FRDY_RUN_SEED`가 unset/empty면 고정 기본 seed를 주입합니다. non-empty 값은 그대로 전달되며 결정론 보장은 런타임이 숫자로 해석하는 경우에 한합니다.
+- `check_love.sh`: 기본적으로 `FRDY_CI_CHECK=1` 기반 Love2D 무팝업 실행 검증을 수행하고, 디스플레이가 없는 자동화 환경에서는 Lua headless bootstrap smoke check로 자동 전환합니다. `FRDY_RUN_SEED` semantics는 기본 Love 실행과 headless fallback 경로에서 동일합니다.
 
 ## 프로젝트 구조
 

--- a/scripts/automation_run_seed.sh
+++ b/scripts/automation_run_seed.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+FRDY_AUTOMATION_DEFAULT_RUN_SEED="424242"
+
+frdy_resolve_automation_run_seed() {
+  local raw_seed="${FRDY_RUN_SEED-}"
+  if [[ -z "$raw_seed" ]]; then
+    printf '%s\n' "$FRDY_AUTOMATION_DEFAULT_RUN_SEED"
+    return 0
+  fi
+
+  printf '%s\n' "$raw_seed"
+}
+
+frdy_run_with_automation_run_seed() {
+  local resolved_seed
+  resolved_seed="$(frdy_resolve_automation_run_seed)"
+  FRDY_RUN_SEED="$resolved_seed" "$@"
+}

--- a/scripts/check_love.sh
+++ b/scripts/check_love.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 CHECK_TIMEOUT_SECONDS=5
+source "$ROOT_DIR/scripts/automation_run_seed.sh"
 
 if command -v timeout >/dev/null 2>&1; then
   TIMEOUT_BIN="timeout"
@@ -42,11 +43,13 @@ is_headless_display_failure() {
 run_headless_smoke_check() {
   local lua_bin
   lua_bin="$(resolve_lua_bin)" || return $?
-  FRDY_CI_CHECK=1 "$TIMEOUT_BIN" "$CHECK_TIMEOUT_SECONDS" "$lua_bin" "$ROOT_DIR/scripts/check_love_headless.lua"
+  frdy_run_with_automation_run_seed env FRDY_CI_CHECK=1 \
+    "$TIMEOUT_BIN" "$CHECK_TIMEOUT_SECONDS" "$lua_bin" "$ROOT_DIR/scripts/check_love_headless.lua"
 }
 
 set +e
-FRDY_CI_CHECK=1 "$TIMEOUT_BIN" "$CHECK_TIMEOUT_SECONDS" love "$ROOT_DIR" >"$TMP_LOG" 2>&1
+frdy_run_with_automation_run_seed env FRDY_CI_CHECK=1 \
+  "$TIMEOUT_BIN" "$CHECK_TIMEOUT_SECONDS" love "$ROOT_DIR" >"$TMP_LOG" 2>&1
 status=$?
 set -e
 

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+source "$ROOT_DIR/scripts/automation_run_seed.sh"
 
 if command -v lua >/dev/null 2>&1; then
   LUA_BIN="lua"
@@ -13,4 +14,5 @@ else
 fi
 
 "$ROOT_DIR/scripts/check_rng_usage.sh"
-"$LUA_BIN" "$ROOT_DIR/tests/run.lua"
+bash "$ROOT_DIR/tests/scripts/automation_run_seed_test.sh"
+frdy_run_with_automation_run_seed "$LUA_BIN" "$ROOT_DIR/tests/run.lua"

--- a/tests/scripts/automation_run_seed_test.sh
+++ b/tests/scripts/automation_run_seed_test.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+source "$ROOT_DIR/scripts/automation_run_seed.sh"
+
+assert_eq() {
+  local expected="$1"
+  local actual="$2"
+  local message="$3"
+  if [[ "$expected" != "$actual" ]]; then
+    echo "automation_run_seed_test: $message (expected '$expected', got '$actual')" >&2
+    exit 1
+  fi
+}
+
+run_check_love_basic_path_test() {
+  local temp_dir
+  temp_dir="$(mktemp -d)"
+  trap 'rm -rf "$temp_dir"' RETURN
+
+  cat >"$temp_dir/timeout" <<'EOF'
+#!/usr/bin/env bash
+shift
+"$@"
+EOF
+  cat >"$temp_dir/love" <<'EOF'
+#!/usr/bin/env bash
+printf '%s' "${FRDY_RUN_SEED-}" >"${FRDY_AUTOMATION_TEST_LOVE_OUT:?}"
+exit 124
+EOF
+  chmod +x "$temp_dir/timeout" "$temp_dir/love"
+
+  PATH="$temp_dir:$PATH" FRDY_AUTOMATION_TEST_LOVE_OUT="$temp_dir/love_seed.txt" \
+    bash "$ROOT_DIR/scripts/check_love.sh"
+
+  local resolved_seed
+  resolved_seed="$(cat "$temp_dir/love_seed.txt")"
+  assert_eq "$FRDY_AUTOMATION_DEFAULT_RUN_SEED" "$resolved_seed" "check_love 기본 경로는 기본 seed를 주입해야 합니다"
+}
+
+run_check_love_fallback_path_test() {
+  local temp_dir
+  temp_dir="$(mktemp -d)"
+  trap 'rm -rf "$temp_dir"' RETURN
+
+  cat >"$temp_dir/timeout" <<'EOF'
+#!/usr/bin/env bash
+shift
+"$@"
+EOF
+  cat >"$temp_dir/love" <<'EOF'
+#!/usr/bin/env bash
+echo "No available video device" >&2
+exit 1
+EOF
+  cat >"$temp_dir/lua" <<'EOF'
+#!/usr/bin/env bash
+printf '%s' "${FRDY_RUN_SEED-}" >"${FRDY_AUTOMATION_TEST_LUA_OUT:?}"
+exit 0
+EOF
+  chmod +x "$temp_dir/timeout" "$temp_dir/love" "$temp_dir/lua"
+
+  PATH="$temp_dir:$PATH" FRDY_RUN_SEED="123" FRDY_AUTOMATION_TEST_LUA_OUT="$temp_dir/lua_seed.txt" \
+    bash "$ROOT_DIR/scripts/check_love.sh"
+
+  local resolved_seed
+  resolved_seed="$(cat "$temp_dir/lua_seed.txt")"
+  assert_eq "123" "$resolved_seed" "check_love fallback 경로는 숫자형 override를 보존해야 합니다"
+}
+
+unset FRDY_RUN_SEED || true
+assert_eq "$FRDY_AUTOMATION_DEFAULT_RUN_SEED" "$(frdy_resolve_automation_run_seed)" "unset seed는 기본값이어야 합니다"
+
+FRDY_RUN_SEED=""
+assert_eq "$FRDY_AUTOMATION_DEFAULT_RUN_SEED" "$(frdy_resolve_automation_run_seed)" "empty seed는 기본값이어야 합니다"
+
+FRDY_RUN_SEED="777"
+assert_eq "777" "$(frdy_resolve_automation_run_seed)" "명시적 override는 그대로 전달되어야 합니다"
+
+FRDY_RUN_SEED="nonnumeric"
+assert_eq "nonnumeric" "$(frdy_resolve_automation_run_seed)" "non-empty override는 helper가 그대로 전달해야 합니다"
+
+unset FRDY_RUN_SEED || true
+run_check_love_basic_path_test
+run_check_love_fallback_path_test


### PR DESCRIPTION
## 요약
- 자동화 경로에서 공용 `run seed` helper를 사용하도록 정리했습니다.
- `run_tests.sh`와 `check_love.sh`가 같은 `FRDY_RUN_SEED` semantics를 공유하도록 맞췄습니다.
- `check_love.sh`의 기본 Love 실행 경로와 headless fallback 경로를 셸 stub 테스트로 검증했습니다.
- README 검증 섹션에 새 자동화 seed 계약을 반영했습니다.

## 배경
- issue #21 본문 중 `StatusContainer` 성능 리스크와 save payload의 `run_seed` 기록은 최신 `main`에서 이미 반영돼 있었습니다.
- 이번 PR은 최신 코드 기준으로 남아 있던 자동화 seed 재현성 범위만 좁게 다룹니다.

## 변경 내용
- `scripts/automation_run_seed.sh` 추가
- `scripts/run_tests.sh`에서 공용 helper와 셸 테스트 사용
- `scripts/check_love.sh`의 기본/fallback 경로에 동일 helper 적용
- `tests/scripts/automation_run_seed_test.sh` 추가
- `README.md` 검증 섹션 갱신

## 검증
- `./scripts/run_tests.sh`
- `./scripts/check_love.sh`
- `FRDY_RUN_SEED=123 ./scripts/run_tests.sh`

## Route
- judge route: `ralplan-then-ralph`
- judge artifact: `.codex-workflows/github-issue-impl-pr-loop/issue-21/judge-route.json`
- ralplan artifacts:
  - `.codex-workflows/ralplan/issue-21-automation-seed-policy/artifacts/plan.md`
  - `.codex-workflows/ralplan/issue-21-automation-seed-policy/artifacts/decision.md`
  - `.codex-workflows/ralplan/issue-21-automation-seed-policy/summary.md`
- ralph artifacts:
  - `.codex-workflows/ralph/issue-21-automation-seed-policy/artifacts/execution-plan.md`
  - `.codex-workflows/ralph/issue-21-automation-seed-policy/summary.md`

## 문서 동기화
- `README.md`를 자동화 seed 계약에 맞게 갱신했습니다.

Closes #21