### PR TITLE
fix: 런 종료와 층 전환 흐름 복구

### DIFF
--- a/src/core/run_save_validators.lua
+++ b/src/core/run_save_validators.lua
@@ -7,6 +7,7 @@ local RunSaveValidators = {}
 
 local CHECKPOINT_KINDS = {
   start_node_select = true,
+  floor_transition_pending = true,
   combat_start = true,
   event_start = true,
   reward_offer_presented = true,

--- a/src/scene/game_scene.lua
+++ b/src/scene/game_scene.lua
@@ -446,7 +446,11 @@ function GameScene:_checkpoint_post_resolution()
   end
 
   if #self:_get_outgoing_edges() == 0 then
-    self:_clear_active_run()
+    if self:_has_next_floor() then
+      self:_write_checkpoint('start_node_select')
+    else
+      self:_clear_active_run()
+    end
     return
   end
 
@@ -740,6 +744,27 @@ function GameScene:_abandon_run()
   self:_finish_run('abandon')
 end
 
+---@return boolean
+function GameScene:_has_next_floor()
+  return self.map.current_floor_index < self.map:get_total_floors()
+end
+
+---@return nil
+function GameScene:_advance_to_next_floor()
+  if not self:_has_next_floor() then
+    self:_finish_run('victory')
+    return
+  end
+
+  self.map:advance_floor()
+  self.phase = START_NODE_SELECT
+  print(i18n.t("combat.floor_cleared"))
+  self:_reset_world_position_for_current_floor()
+  self:_write_checkpoint('start_node_select')
+  local floor = self.map:get_current_floor()
+  self:_show_start_node_select(floor and floor:get_start_nodes() or {})
+end
+
 function GameScene:_check_next_move()
   if not self.current_node then
     return
@@ -748,8 +773,7 @@ function GameScene:_check_next_move()
   local edges = self:_get_outgoing_edges()
 
   if #edges == 0 then
-    print(i18n.t("combat.floor_cleared"))
-    self:_finish_run('victory')
+    self:_advance_to_next_floor()
     return
   elseif #edges == 1 then
     local started = self:_on_edge_selected(edges[1])
@@ -1016,7 +1040,7 @@ end
 ---@return nil
 function GameScene:_continue_after_settlement()
   if #self:_get_outgoing_edges() == 0 then
-    self:_finish_run('victory')
+    self:_advance_to_next_floor()
     return
   end
 

--- a/src/scene/game_scene.lua
+++ b/src/scene/game_scene.lua
@@ -413,6 +413,10 @@ function GameScene:_resume_from_checkpoint(checkpoint_kind)
     self:_resume_travel_start()
     return
   end
+  if checkpoint_kind == 'floor_transition_pending' then
+    self:_advance_to_next_floor()
+    return
+  end
 
   self:_show_start_node_select(floor and floor:get_start_nodes() or {})
 end
@@ -447,7 +451,7 @@ function GameScene:_checkpoint_post_resolution()
 
   if #self:_get_outgoing_edges() == 0 then
     if self:_has_next_floor() then
-      self:_write_checkpoint('start_node_select')
+      self:_write_checkpoint('floor_transition_pending')
     else
       self:_clear_active_run()
     end

--- a/tests/unit/game_scene_progression_test.lua
+++ b/tests/unit/game_scene_progression_test.lua
@@ -27,6 +27,7 @@ local function build_fake_scene(edge_count, has_pending_offers, current_floor_in
   local start_select_shown = false
   local advanced_floor = false
   local reset_world = false
+  local call_order = {}
 
   local floor = {
     get_edges_from = function()
@@ -67,6 +68,7 @@ local function build_fake_scene(edge_count, has_pending_offers, current_floor_in
         return total_floors or 1
       end,
       advance_floor = function(map)
+        call_order[#call_order + 1] = 'advance_floor'
         map.current_floor_index = map.current_floor_index + 1
         advanced_floor = true
       end,
@@ -83,6 +85,7 @@ local function build_fake_scene(edge_count, has_pending_offers, current_floor_in
       finished_reason = reason
     end,
     _write_checkpoint = function(_, kind)
+      call_order[#call_order + 1] = kind
       wrote_checkpoint = true
       checkpoint_kind = kind
       return true
@@ -94,6 +97,7 @@ local function build_fake_scene(edge_count, has_pending_offers, current_floor_in
       reset_world = true
     end,
     _show_start_node_select = function()
+      call_order[#call_order + 1] = 'show_start_node_select'
       start_select_shown = true
     end,
   }
@@ -109,6 +113,7 @@ local function build_fake_scene(edge_count, has_pending_offers, current_floor_in
       advanced_floor = advanced_floor,
       reset_world = reset_world,
       current_floor_index = scene.map.current_floor_index,
+      call_order = call_order,
     }
   end
 end
@@ -153,6 +158,8 @@ function suite.test_continue_after_settlement_advances_to_next_floor_when_curren
   TestHelper.assert_true(state.reset_world)
   TestHelper.assert_true(state.start_select_shown)
   TestHelper.assert_equal(state.current_floor_index, 2)
+  TestHelper.assert_equal(state.call_order[1], 'advance_floor')
+  TestHelper.assert_equal(state.call_order[2], 'start_node_select')
 end
 
 ---@return nil
@@ -219,7 +226,7 @@ function suite.test_checkpoint_post_resolution_clears_active_run_when_node_flow_
 end
 
 ---@return nil
-function suite.test_checkpoint_post_resolution_keeps_run_for_next_floor_start()
+function suite.test_checkpoint_post_resolution_writes_floor_transition_checkpoint_for_next_floor_start()
   local checkpoints = {}
   local cleared = false
   local scene = {
@@ -257,7 +264,31 @@ function suite.test_checkpoint_post_resolution_keeps_run_for_next_floor_start()
 
   TestHelper.assert_false(cleared)
   TestHelper.assert_equal(#checkpoints, 1)
-  TestHelper.assert_equal(checkpoints[1], 'start_node_select')
+  TestHelper.assert_equal(checkpoints[1], 'floor_transition_pending')
+end
+
+---@return nil
+function suite.test_resume_from_floor_transition_pending_advances_to_next_floor()
+  local advanced = false
+  local scene = {
+    _advance_to_next_floor = function()
+      advanced = true
+    end,
+    map = {
+      get_current_floor = function()
+        return {
+          get_start_nodes = function()
+            return {}
+          end,
+        }
+      end,
+    },
+  }
+  setmetatable(scene, {__index = GameScene})
+
+  scene:_resume_from_checkpoint('floor_transition_pending')
+
+  TestHelper.assert_true(advanced)
 end
 
 ---@return nil

--- a/tests/unit/game_scene_progression_test.lua
+++ b/tests/unit/game_scene_progression_test.lua
@@ -191,6 +191,10 @@ function suite.test_checkpoint_post_resolution_clears_active_run_when_node_flow_
     },
     current_node = { id = 1 },
     map = {
+      current_floor_index = 1,
+      get_total_floors = function()
+        return 1
+      end,
       get_current_floor = function()
         return {
           get_edges_from = function()

--- a/tests/unit/game_scene_progression_test.lua
+++ b/tests/unit/game_scene_progression_test.lua
@@ -19,10 +19,14 @@ function suite.after_each()
   package.loaded['src.scene.run_end_scene'] = original_run_end_scene_module
 end
 
-local function build_fake_scene(edge_count, has_pending_offers)
+local function build_fake_scene(edge_count, has_pending_offers, current_floor_index, total_floors)
   local finished_reason = nil
   local wrote_checkpoint = false
   local checked_next_move = false
+  local checkpoint_kind = nil
+  local start_select_shown = false
+  local advanced_floor = false
+  local reset_world = false
 
   local floor = {
     get_edges_from = function()
@@ -38,6 +42,16 @@ local function build_fake_scene(edge_count, has_pending_offers)
       end
       return edges
     end,
+    get_start_nodes = function()
+      return {
+        {
+          id = 101,
+          get_position = function()
+            return {x = 0, y = 0}
+          end,
+        },
+      }
+    end,
   }
 
   local scene = {
@@ -45,8 +59,16 @@ local function build_fake_scene(edge_count, has_pending_offers)
       id = 10,
     },
     map = {
+      current_floor_index = current_floor_index or 1,
       get_current_floor = function()
         return floor
+      end,
+      get_total_floors = function()
+        return total_floors or 1
+      end,
+      advance_floor = function(map)
+        map.current_floor_index = map.current_floor_index + 1
+        advanced_floor = true
       end,
     },
     reward_manager = {
@@ -60,43 +82,77 @@ local function build_fake_scene(edge_count, has_pending_offers)
     _finish_run = function(_, reason)
       finished_reason = reason
     end,
-    _write_checkpoint = function()
+    _write_checkpoint = function(_, kind)
       wrote_checkpoint = true
+      checkpoint_kind = kind
       return true
     end,
     _check_next_move = function()
       checked_next_move = true
     end,
+    _reset_world_position_for_current_floor = function()
+      reset_world = true
+    end,
+    _show_start_node_select = function()
+      start_select_shown = true
+    end,
   }
   setmetatable(scene, {__index = GameScene})
 
   return scene, function()
-    return finished_reason, wrote_checkpoint, checked_next_move
+    return {
+      finished_reason = finished_reason,
+      wrote_checkpoint = wrote_checkpoint,
+      checkpoint_kind = checkpoint_kind,
+      checked_next_move = checked_next_move,
+      start_select_shown = start_select_shown,
+      advanced_floor = advanced_floor,
+      reset_world = reset_world,
+      current_floor_index = scene.map.current_floor_index,
+    }
   end
 end
 
 ---@return nil
 function suite.test_continue_after_settlement_finishes_run_without_path_checkpoint_on_last_node()
-  local scene, result = build_fake_scene(0, false)
+  local scene, result = build_fake_scene(0, false, 3, 3)
 
   scene:_enter_settlement_or_continue()
 
-  local finished_reason, wrote_checkpoint, checked_next_move = result()
-  TestHelper.assert_equal(finished_reason, 'victory')
-  TestHelper.assert_false(wrote_checkpoint)
-  TestHelper.assert_false(checked_next_move)
+  local state = result()
+  TestHelper.assert_equal(state.finished_reason, 'victory')
+  TestHelper.assert_false(state.wrote_checkpoint)
+  TestHelper.assert_false(state.checked_next_move)
+  TestHelper.assert_false(state.advanced_floor)
 end
 
 ---@return nil
 function suite.test_continue_after_settlement_writes_path_checkpoint_when_next_edge_exists()
-  local scene, result = build_fake_scene(1, false)
+  local scene, result = build_fake_scene(1, false, 1, 3)
 
   scene:_enter_settlement_or_continue()
 
-  local finished_reason, wrote_checkpoint, checked_next_move = result()
-  TestHelper.assert_equal(finished_reason, nil)
-  TestHelper.assert_true(wrote_checkpoint)
-  TestHelper.assert_true(checked_next_move)
+  local state = result()
+  TestHelper.assert_equal(state.finished_reason, nil)
+  TestHelper.assert_true(state.wrote_checkpoint)
+  TestHelper.assert_equal(state.checkpoint_kind, 'path_ready')
+  TestHelper.assert_true(state.checked_next_move)
+end
+
+---@return nil
+function suite.test_continue_after_settlement_advances_to_next_floor_when_current_floor_is_not_final()
+  local scene, result = build_fake_scene(0, false, 1, 3)
+
+  scene:_enter_settlement_or_continue()
+
+  local state = result()
+  TestHelper.assert_equal(state.finished_reason, nil)
+  TestHelper.assert_true(state.wrote_checkpoint)
+  TestHelper.assert_equal(state.checkpoint_kind, 'start_node_select')
+  TestHelper.assert_true(state.advanced_floor)
+  TestHelper.assert_true(state.reset_world)
+  TestHelper.assert_true(state.start_select_shown)
+  TestHelper.assert_equal(state.current_floor_index, 2)
 end
 
 ---@return nil
@@ -156,6 +212,48 @@ function suite.test_checkpoint_post_resolution_clears_active_run_when_node_flow_
   scene:_checkpoint_post_resolution()
 
   TestHelper.assert_true(cleared)
+end
+
+---@return nil
+function suite.test_checkpoint_post_resolution_keeps_run_for_next_floor_start()
+  local checkpoints = {}
+  local cleared = false
+  local scene = {
+    reward_manager = {
+      has_pending_offers = function()
+        return false
+      end,
+    },
+    current_node = { id = 1 },
+    map = {
+      current_floor_index = 1,
+      get_total_floors = function()
+        return 3
+      end,
+      get_current_floor = function()
+        return {
+          get_edges_from = function()
+            return {}
+          end,
+        }
+      end,
+    },
+    _write_checkpoint = function(_, checkpoint_kind)
+      checkpoints[#checkpoints + 1] = checkpoint_kind
+      return true
+    end,
+    _clear_active_run = function()
+      cleared = true
+      return true
+    end,
+  }
+  setmetatable(scene, {__index = GameScene})
+
+  scene:_checkpoint_post_resolution()
+
+  TestHelper.assert_false(cleared)
+  TestHelper.assert_equal(#checkpoints, 1)
+  TestHelper.assert_equal(checkpoints[1], 'start_node_select')
 end
 
 ---@return nil

--- a/tests/unit/run_save_validators_test.lua
+++ b/tests/unit/run_save_validators_test.lua
@@ -166,6 +166,64 @@ function suite.test_save_payload_accepts_travel_start_and_pending_target_node()
 end
 
 ---@return nil
+function suite.test_save_payload_accepts_floor_transition_pending_checkpoint()
+  local payload, err = RunSaveValidators.save_payload({
+    version = 2,
+    run_seed = 1234,
+    checkpoint = {
+      kind = 'floor_transition_pending',
+    },
+    systems = {
+      run_context = {
+        run_seed = 1234,
+        streams = {},
+      },
+      map_progress = {
+        current_floor_index = 1,
+        current_node_id = 11,
+        pending_target_node_id = nil,
+        completed_node_ids = { 11 },
+      },
+      hero = {
+        hp = 50,
+        max_hp = 50,
+        attack = 8,
+        defense = 2,
+        speed = 8,
+        level = 1,
+        experience = 0,
+        mental_load = 0,
+        current_turn = 0,
+        cooldown_tracker = {},
+        action_patterns = {},
+      },
+      spell_book = {
+        spells = {},
+        used_this_turn = {},
+        reserved = {},
+        reserved_stack = {},
+      },
+      mana = {
+        current_mana = 100,
+        max_mana = 100,
+        reserved_mana = 0,
+      },
+      suspicion = {
+        level = 0,
+        max_level = 100,
+      },
+      reward = {
+        offer_queue = {},
+      },
+    },
+  })
+
+  TestHelper.assert_equal(err, nil)
+  TestHelper.assert_equal(payload.checkpoint.kind, 'floor_transition_pending')
+  TestHelper.assert_equal(payload.systems.map_progress.current_floor_index, 1)
+end
+
+---@return nil
 function suite.test_action_pattern_rank_clamps_invalid_zero_to_one()
   local pattern = RunSaveValidators.action_pattern({
     id = 'slash',


### PR DESCRIPTION
## 요약
- 마지막 노드 도달 시 현재 층이 마지막 층이 아니면 다음 층 시작 노드 선택으로 전환되도록 수정
- 전투 패배 시 런 종료 화면으로 전환되도록 연결
- 런 종료 화면과 관련 locale, progression 회귀 테스트 추가

## 검증
- `./scripts/run_tests.sh` ✅
- `./scripts/check_love.sh` / `FRDY_CI_CHECK=1 timeout 5 love .` ❌
  - 자동화 환경에서 SDL video subsystem 초기화 실패 (`The video driver did not add any displays`)

## 관련 이슈
- Closes #44

## Route
- `direct-impl`
- judge artifact: `.codex-workflows/github-issue-impl-pr-loop/issue-44/judge-route.json`

## 문서 동기화
- 문서 업데이트 불필요: 런 종료/층 전환 동작 복구로 기존 게임 컨셉/아키텍처 설명 범위를 넘지 않음
