### PR TITLE
docs: StatusContainer 인덱스 불변식 문서화

### DIFF
--- a/CLASS_DIAGRAM.md
+++ b/CLASS_DIAGRAM.md
@@ -108,7 +108,15 @@ classDiagram
   class Hero
   class Enemy
   class ActionPattern
-  class StatusContainer
+  class StatusContainer {
+    -statuses
+    -_status_by_uid
+    -_alive_instances
+    -_next_uid
+    +emit(hook_name, ctx)
+    +remove(uid)
+    +restore(snap)
+  }
   class StatusRegistry
 
   CombatHandler --> CombatManager
@@ -127,6 +135,12 @@ classDiagram
   Hero --> ActionPattern
   Enemy --> ActionPattern
 ```
+
+상태 컨테이너 메모:
+
+- `StatusContainer`는 상태 목록 외에 UID 인덱스와 생존 인덱스를 함께 유지합니다.
+- `emit()`은 snapshot 순회 + `_alive_instances` 확인으로, 순회 도중 제거된 상태 hook를 다시 호출하지 않는 것을 보장합니다.
+- `remove()`와 `restore()`는 UID 변경/복원 이후에도 `_status_by_uid`가 stale alias를 남기지 않도록 재매핑 책임을 집니다.
 
 ## 5) 주문/보상/이벤트 시스템
 

--- a/GAME_CONCEPT.md
+++ b/GAME_CONCEPT.md
@@ -71,6 +71,15 @@
 - 전투 엔티티: `Hero`, `Enemy`, `ActionPattern`
 - 상태효과: `StatusContainer`, `StatusRegistry`
 
+`StatusContainer` 유지보수 불변식:
+
+- `emit()`은 현재 상태 목록의 snapshot을 기준으로 순회하고, 실제 호출 직전에는 `_alive_instances`를 확인합니다.
+  - 따라서 hook 실행 중 다른 상태가 제거돼도 이미 삭제된 인스턴스를 다시 실행하지 않아야 합니다.
+- UID 조회는 `_status_by_uid`가 맡지만, hook에서 `instance.uid`가 바뀔 수 있으므로 add/remove 경로는 기존 UID 별칭과 새 UID 매핑을 함께 정리해야 합니다.
+  - 특히 `on_apply`, 런타임 hook, `on_remove`에서 UID가 변해도 stale 인덱스가 남지 않아야 합니다.
+- `restore()`는 snapshot을 되살릴 때 `statuses`만 채우지 않고 `_status_by_uid`, `_alive_instances`, `_next_uid`를 함께 재구축해야 합니다.
+  - 복원 직후에도 `remove(uid)`와 후속 `emit()`이 원본 런타임과 같은 기준으로 동작해야 합니다.
+
 핵심 흐름:
 
 1. Planning phase에서 주문/개입 계획 수립


### PR DESCRIPTION
## 요약
- `GAME_CONCEPT.md`에 StatusContainer 유지보수 불변식을 추가했습니다.
- `CLASS_DIAGRAM.md`의 전투/상태 섹션에 UID/생존 인덱스 책임과 핵심 메서드를 보강했습니다.

## 검증
- `./scripts/run_tests.sh` 통과
- `./scripts/check_love.sh` 통과

## 관련 이슈
- closes #30

## Route
- chosen route: `direct-impl`
- judge artifact: `.codex-workflows/github-issue-impl-pr/issue-30/judge-route.json`

## 문서 동기화
- 이 PR 자체가 문서 보강 이슈를 해결하므로 추가 문서 동기화는 불필요합니다.