### PR TITLE
fix(core): 다음 층 전환 흐름 복구 (#48)

### DIFF
--- a/src/core/run_save_validators.lua
+++ b/src/core/run_save_validators.lua
@@ -7,12 +7,12 @@ local RunSaveValidators = {}
 
 local CHECKPOINT_KINDS = {
   start_node_select = true,
-  floor_transition_pending = true,
   combat_start = true,
   event_start = true,
   reward_offer_presented = true,
   path_ready = true,
   travel_start = true,
+  floor_transition_pending = true,
 }
 
 local ACTION_PATTERN_TYPES = {

--- a/src/scene/game_scene.lua
+++ b/src/scene/game_scene.lua
@@ -413,6 +413,10 @@ function GameScene:_resume_from_checkpoint(checkpoint_kind)
     self:_resume_travel_start()
     return
   end
+  if checkpoint_kind == 'floor_transition_pending' then
+    self:_advance_to_next_floor()
+    return
+  end
 
   self:_show_start_node_select(floor and floor:get_start_nodes() or {})
 end
@@ -449,7 +453,7 @@ function GameScene:_checkpoint_post_resolution()
     if self:_is_last_floor() then
       self:_clear_active_run()
     else
-      self:_write_checkpoint('start_node_select')
+      self:_write_checkpoint('floor_transition_pending')
     end
     return
   end

--- a/src/scene/game_scene.lua
+++ b/src/scene/game_scene.lua
@@ -413,10 +413,6 @@ function GameScene:_resume_from_checkpoint(checkpoint_kind)
     self:_resume_travel_start()
     return
   end
-  if checkpoint_kind == 'floor_transition_pending' then
-    self:_advance_to_next_floor()
-    return
-  end
 
   self:_show_start_node_select(floor and floor:get_start_nodes() or {})
 end
@@ -450,10 +446,10 @@ function GameScene:_checkpoint_post_resolution()
   end
 
   if #self:_get_outgoing_edges() == 0 then
-    if self:_has_next_floor() then
-      self:_write_checkpoint('floor_transition_pending')
-    else
+    if self:_is_last_floor() then
       self:_clear_active_run()
+    else
+      self:_write_checkpoint('start_node_select')
     end
     return
   end
@@ -749,24 +745,25 @@ function GameScene:_abandon_run()
 end
 
 ---@return boolean
-function GameScene:_has_next_floor()
-  return self.map.current_floor_index < self.map:get_total_floors()
+function GameScene:_is_last_floor()
+  if not self.map or not self.map.get_total_floors then
+    return true
+  end
+
+  return self.map.current_floor_index >= self.map:get_total_floors()
 end
 
----@return nil
+---@return boolean
 function GameScene:_advance_to_next_floor()
-  if not self:_has_next_floor() then
-    self:_finish_run('victory')
-    return
+  if self:_is_last_floor() then
+    return false
   end
 
   self.map:advance_floor()
-  self.phase = START_NODE_SELECT
-  print(i18n.t("combat.floor_cleared"))
   self:_reset_world_position_for_current_floor()
   self:_write_checkpoint('start_node_select')
-  local floor = self.map:get_current_floor()
-  self:_show_start_node_select(floor and floor:get_start_nodes() or {})
+  self:_show_start_node_select(self.map:get_current_floor():get_start_nodes())
+  return true
 end
 
 function GameScene:_check_next_move()
@@ -777,7 +774,10 @@ function GameScene:_check_next_move()
   local edges = self:_get_outgoing_edges()
 
   if #edges == 0 then
-    self:_advance_to_next_floor()
+    print(i18n.t("combat.floor_cleared"))
+    if not self:_advance_to_next_floor() then
+      self:_finish_run('victory')
+    end
     return
   elseif #edges == 1 then
     local started = self:_on_edge_selected(edges[1])
@@ -1044,7 +1044,9 @@ end
 ---@return nil
 function GameScene:_continue_after_settlement()
   if #self:_get_outgoing_edges() == 0 then
-    self:_advance_to_next_floor()
+    if not self:_advance_to_next_floor() then
+      self:_finish_run('victory')
+    end
     return
   end
 

--- a/tests/unit/game_scene_progression_test.lua
+++ b/tests/unit/game_scene_progression_test.lua
@@ -258,7 +258,7 @@ function suite.test_checkpoint_post_resolution_preserves_run_for_next_floor_star
   scene:_checkpoint_post_resolution()
 
   TestHelper.assert_false(cleared)
-  TestHelper.assert_equal(checkpoint_kind, 'start_node_select')
+  TestHelper.assert_equal(checkpoint_kind, 'floor_transition_pending')
 end
 
 ---@return nil
@@ -477,6 +477,51 @@ function suite.test_resume_from_travel_checkpoint_enters_selected_target_node()
   TestHelper.assert_equal(scene.current_node.id, 33)
   TestHelper.assert_true(entered)
   TestHelper.assert_equal(scene.pending_target_node_id, nil)
+end
+
+---@return nil
+function suite.test_resume_from_floor_transition_pending_advances_to_next_floor()
+  local advanced = false
+  local checkpoint_kind = nil
+  local selected_start_nodes = nil
+  local start_nodes = {
+    { id = 401 },
+  }
+  local scene = {
+    map = {
+      current_floor_index = 1,
+      get_total_floors = function()
+        return 2
+      end,
+      advance_floor = function(map)
+        advanced = true
+        map.current_floor_index = map.current_floor_index + 1
+      end,
+      get_current_floor = function()
+        return {
+          get_start_nodes = function()
+            return start_nodes
+          end,
+        }
+      end,
+      set_current_node = function() end,
+    },
+    _write_checkpoint = function(_, kind)
+      checkpoint_kind = kind
+      return true
+    end,
+    _reset_world_position_for_current_floor = function() end,
+    _show_start_node_select = function(_, nodes)
+      selected_start_nodes = nodes
+    end,
+  }
+  setmetatable(scene, { __index = GameScene })
+
+  scene:_resume_from_checkpoint('floor_transition_pending')
+
+  TestHelper.assert_true(advanced)
+  TestHelper.assert_equal(checkpoint_kind, 'start_node_select')
+  TestHelper.assert_equal(selected_start_nodes, start_nodes)
 end
 
 ---@return nil

--- a/tests/unit/game_scene_progression_test.lua
+++ b/tests/unit/game_scene_progression_test.lua
@@ -19,15 +19,10 @@ function suite.after_each()
   package.loaded['src.scene.run_end_scene'] = original_run_end_scene_module
 end
 
-local function build_fake_scene(edge_count, has_pending_offers, current_floor_index, total_floors)
+local function build_fake_scene(edge_count, has_pending_offers)
   local finished_reason = nil
   local wrote_checkpoint = false
   local checked_next_move = false
-  local checkpoint_kind = nil
-  local start_select_shown = false
-  local advanced_floor = false
-  local reset_world = false
-  local call_order = {}
 
   local floor = {
     get_edges_from = function()
@@ -43,16 +38,6 @@ local function build_fake_scene(edge_count, has_pending_offers, current_floor_in
       end
       return edges
     end,
-    get_start_nodes = function()
-      return {
-        {
-          id = 101,
-          get_position = function()
-            return {x = 0, y = 0}
-          end,
-        },
-      }
-    end,
   }
 
   local scene = {
@@ -60,17 +45,8 @@ local function build_fake_scene(edge_count, has_pending_offers, current_floor_in
       id = 10,
     },
     map = {
-      current_floor_index = current_floor_index or 1,
       get_current_floor = function()
         return floor
-      end,
-      get_total_floors = function()
-        return total_floors or 1
-      end,
-      advance_floor = function(map)
-        call_order[#call_order + 1] = 'advance_floor'
-        map.current_floor_index = map.current_floor_index + 1
-        advanced_floor = true
       end,
     },
     reward_manager = {
@@ -84,82 +60,105 @@ local function build_fake_scene(edge_count, has_pending_offers, current_floor_in
     _finish_run = function(_, reason)
       finished_reason = reason
     end,
-    _write_checkpoint = function(_, kind)
-      call_order[#call_order + 1] = kind
+    _write_checkpoint = function()
       wrote_checkpoint = true
-      checkpoint_kind = kind
       return true
     end,
     _check_next_move = function()
       checked_next_move = true
     end,
-    _reset_world_position_for_current_floor = function()
-      reset_world = true
-    end,
-    _show_start_node_select = function()
-      call_order[#call_order + 1] = 'show_start_node_select'
-      start_select_shown = true
-    end,
   }
   setmetatable(scene, {__index = GameScene})
 
   return scene, function()
-    return {
-      finished_reason = finished_reason,
-      wrote_checkpoint = wrote_checkpoint,
-      checkpoint_kind = checkpoint_kind,
-      checked_next_move = checked_next_move,
-      start_select_shown = start_select_shown,
-      advanced_floor = advanced_floor,
-      reset_world = reset_world,
-      current_floor_index = scene.map.current_floor_index,
-      call_order = call_order,
-    }
+    return finished_reason, wrote_checkpoint, checked_next_move
   end
 end
 
 ---@return nil
 function suite.test_continue_after_settlement_finishes_run_without_path_checkpoint_on_last_node()
-  local scene, result = build_fake_scene(0, false, 3, 3)
+  local scene, result = build_fake_scene(0, false)
 
   scene:_enter_settlement_or_continue()
 
-  local state = result()
-  TestHelper.assert_equal(state.finished_reason, 'victory')
-  TestHelper.assert_false(state.wrote_checkpoint)
-  TestHelper.assert_false(state.checked_next_move)
-  TestHelper.assert_false(state.advanced_floor)
+  local finished_reason, wrote_checkpoint, checked_next_move = result()
+  TestHelper.assert_equal(finished_reason, 'victory')
+  TestHelper.assert_false(wrote_checkpoint)
+  TestHelper.assert_false(checked_next_move)
 end
 
 ---@return nil
 function suite.test_continue_after_settlement_writes_path_checkpoint_when_next_edge_exists()
-  local scene, result = build_fake_scene(1, false, 1, 3)
+  local scene, result = build_fake_scene(1, false)
 
   scene:_enter_settlement_or_continue()
 
-  local state = result()
-  TestHelper.assert_equal(state.finished_reason, nil)
-  TestHelper.assert_true(state.wrote_checkpoint)
-  TestHelper.assert_equal(state.checkpoint_kind, 'path_ready')
-  TestHelper.assert_true(state.checked_next_move)
+  local finished_reason, wrote_checkpoint, checked_next_move = result()
+  TestHelper.assert_equal(finished_reason, nil)
+  TestHelper.assert_true(wrote_checkpoint)
+  TestHelper.assert_true(checked_next_move)
 end
 
 ---@return nil
-function suite.test_continue_after_settlement_advances_to_next_floor_when_current_floor_is_not_final()
-  local scene, result = build_fake_scene(0, false, 1, 3)
+function suite.test_continue_after_settlement_advances_to_next_floor_when_current_floor_is_terminal()
+  local advanced = false
+  local checkpoint_kind = nil
+  local shown_floor = nil
+  local start_nodes = {
+    { id = 201 },
+    { id = 202 },
+  }
+  local scene = {
+    current_node = { id = 10 },
+    map = {
+      current_floor_index = 1,
+      get_total_floors = function()
+        return 3
+      end,
+      advance_floor = function(map)
+        advanced = true
+        map.current_floor_index = map.current_floor_index + 1
+      end,
+      get_current_floor = function()
+        return {
+          floor_index = 2,
+          get_edges_from = function()
+            return {}
+          end,
+          get_start_nodes = function()
+            return start_nodes
+          end,
+        }
+      end,
+      set_current_node = function() end,
+    },
+    reward_manager = {
+      has_pending_offers = function()
+        return false
+      end,
+    },
+    _write_checkpoint = function(_, kind)
+      checkpoint_kind = kind
+      return true
+    end,
+    _reset_world_position_for_current_floor = function(self)
+      self.current_node = nil
+    end,
+    _show_start_node_select = function(_, nodes)
+      shown_floor = nodes
+    end,
+    _finish_run = function()
+      error('_finish_run should not be called')
+    end,
+  }
+  setmetatable(scene, { __index = GameScene })
 
-  scene:_enter_settlement_or_continue()
+  scene:_continue_after_settlement()
 
-  local state = result()
-  TestHelper.assert_equal(state.finished_reason, nil)
-  TestHelper.assert_true(state.wrote_checkpoint)
-  TestHelper.assert_equal(state.checkpoint_kind, 'start_node_select')
-  TestHelper.assert_true(state.advanced_floor)
-  TestHelper.assert_true(state.reset_world)
-  TestHelper.assert_true(state.start_select_shown)
-  TestHelper.assert_equal(state.current_floor_index, 2)
-  TestHelper.assert_equal(state.call_order[1], 'advance_floor')
-  TestHelper.assert_equal(state.call_order[2], 'start_node_select')
+  TestHelper.assert_true(advanced)
+  TestHelper.assert_equal(checkpoint_kind, 'start_node_select')
+  TestHelper.assert_equal(shown_floor, start_nodes)
+  TestHelper.assert_equal(scene.current_node, nil)
 end
 
 ---@return nil
@@ -198,10 +197,6 @@ function suite.test_checkpoint_post_resolution_clears_active_run_when_node_flow_
     },
     current_node = { id = 1 },
     map = {
-      current_floor_index = 1,
-      get_total_floors = function()
-        return 1
-      end,
       get_current_floor = function()
         return {
           get_edges_from = function()
@@ -226,9 +221,9 @@ function suite.test_checkpoint_post_resolution_clears_active_run_when_node_flow_
 end
 
 ---@return nil
-function suite.test_checkpoint_post_resolution_writes_floor_transition_checkpoint_for_next_floor_start()
-  local checkpoints = {}
+function suite.test_checkpoint_post_resolution_preserves_run_for_next_floor_start_select()
   local cleared = false
+  local checkpoint_kind = nil
   local scene = {
     reward_manager = {
       has_pending_offers = function()
@@ -249,8 +244,8 @@ function suite.test_checkpoint_post_resolution_writes_floor_transition_checkpoin
         }
       end,
     },
-    _write_checkpoint = function(_, checkpoint_kind)
-      checkpoints[#checkpoints + 1] = checkpoint_kind
+    _write_checkpoint = function(_, kind)
+      checkpoint_kind = kind
       return true
     end,
     _clear_active_run = function()
@@ -258,37 +253,12 @@ function suite.test_checkpoint_post_resolution_writes_floor_transition_checkpoin
       return true
     end,
   }
-  setmetatable(scene, {__index = GameScene})
+  setmetatable(scene, { __index = GameScene })
 
   scene:_checkpoint_post_resolution()
 
   TestHelper.assert_false(cleared)
-  TestHelper.assert_equal(#checkpoints, 1)
-  TestHelper.assert_equal(checkpoints[1], 'floor_transition_pending')
-end
-
----@return nil
-function suite.test_resume_from_floor_transition_pending_advances_to_next_floor()
-  local advanced = false
-  local scene = {
-    _advance_to_next_floor = function()
-      advanced = true
-    end,
-    map = {
-      get_current_floor = function()
-        return {
-          get_start_nodes = function()
-            return {}
-          end,
-        }
-      end,
-    },
-  }
-  setmetatable(scene, {__index = GameScene})
-
-  scene:_resume_from_checkpoint('floor_transition_pending')
-
-  TestHelper.assert_true(advanced)
+  TestHelper.assert_equal(checkpoint_kind, 'start_node_select')
 end
 
 ---@return nil
@@ -416,6 +386,60 @@ function suite.test_check_next_move_single_edge_falls_back_to_selector_when_trav
   scene:_check_next_move()
 
   TestHelper.assert_true(showed_selector)
+end
+
+---@return nil
+function suite.test_check_next_move_advances_to_next_floor_when_no_edges_remain_before_final_floor()
+  local advanced = false
+  local checkpoint_kind = nil
+  local selected_start_nodes = nil
+  local start_nodes = {
+    { id = 301 },
+  }
+  local scene = {
+    current_node = { id = 10 },
+    map = {
+      current_floor_index = 1,
+      get_total_floors = function()
+        return 2
+      end,
+      advance_floor = function(map)
+        advanced = true
+        map.current_floor_index = map.current_floor_index + 1
+      end,
+      get_current_floor = function()
+        return {
+          get_edges_from = function()
+            return {}
+          end,
+          get_start_nodes = function()
+            return start_nodes
+          end,
+        }
+      end,
+      set_current_node = function() end,
+    },
+    _write_checkpoint = function(_, kind)
+      checkpoint_kind = kind
+      return true
+    end,
+    _reset_world_position_for_current_floor = function(self)
+      self.current_node = nil
+    end,
+    _show_start_node_select = function(_, nodes)
+      selected_start_nodes = nodes
+    end,
+    _finish_run = function()
+      error('_finish_run should not be called before final floor')
+    end,
+  }
+  setmetatable(scene, { __index = GameScene })
+
+  scene:_check_next_move()
+
+  TestHelper.assert_true(advanced)
+  TestHelper.assert_equal(checkpoint_kind, 'start_node_select')
+  TestHelper.assert_equal(selected_start_nodes, start_nodes)
 end
 
 ---@return nil


### PR DESCRIPTION
## 요약
- 층 종료 분기를 마지막 층과 중간층으로 분리해 중간층에서는 다음 층 시작 선택으로 전환되도록 수정했습니다.
- 체크포인트 정리 로직도 마지막 층 여부를 따르도록 맞춰 active run이 중간층에서 지워지지 않게 했습니다.
- 진행 회귀 테스트를 추가해 정산 후 전환, 체크포인트 보존, `_check_next_move()` 전환을 검증했습니다.

## 관련 이슈
- Closes #48

## 구현 경로
- judge route: `ralph-only`
- judge artifact: `.codex-workflows/github-issue-impl-pr/issue-48/judge-route.json`
- ralph artifacts: `.codex-workflows/ralph/issue-48-floor-transition/`

## 검증
- `./scripts/run_tests.sh` ✅
- `./scripts/check_love.sh` ✅

## 문서 동기화
- 이번 변경은 진행 분기와 테스트 보강에 한정되어 `GAME_CONCEPT.md`, `CLASS_DIAGRAM.md`, `README.md`의 구조/용어 변경이 없어 문서 업데이트는 불필요합니다.
