### PR TITLE
fix(combat): suffix 재계산 actor-slot 보존 범위 수정 (#50)

### DIFF
--- a/src/combat/timeline_manager.lua
+++ b/src/combat/timeline_manager.lua
@@ -110,6 +110,9 @@ end
 ---@param intervention table
 ---@return number
 local function get_actor_slot_intervention_max_index(intervention)
+  if intervention.type == "remove" then
+    return math.huge
+  end
   if intervention.type == "swap" then
     return math.max(intervention.a or intervention.index or 1, intervention.b or intervention.index or 1)
   end

--- a/src/combat/timeline_manager.lua
+++ b/src/combat/timeline_manager.lua
@@ -107,13 +107,26 @@ function TimelineManager:_recalculate_from(start_index, force_preserve_actor_slo
 end
 
 ---@param start_index? number
+---@param intervention table
+---@return number
+local function get_actor_slot_intervention_max_index(intervention)
+  if intervention.type == "swap" then
+    return math.max(intervention.a or intervention.index or 1, intervention.b or intervention.index or 1)
+  end
+  if intervention.type == "delay" then
+    return math.max(intervention.index or 1, intervention.to_index or intervention.index or 1)
+  end
+  return intervention.index or 1
+end
+
+---@param start_index? number
 ---@return boolean
 function TimelineManager:_has_actor_slot_intervention_from(start_index)
   local threshold = start_index or 1
   for _, intervention in ipairs(self.interventions) do
     local itype = intervention.type
-    local index = intervention.index or 1
-    if (itype == "swap" or itype == "delay" or itype == "remove") and index >= threshold then
+    local max_index = get_actor_slot_intervention_max_index(intervention)
+    if (itype == "swap" or itype == "delay" or itype == "remove") and max_index >= threshold then
       return true
     end
   end

--- a/src/combat/timeline_manager.lua
+++ b/src/combat/timeline_manager.lua
@@ -109,9 +109,11 @@ end
 ---@param start_index? number
 ---@return boolean
 function TimelineManager:_has_actor_slot_intervention_from(start_index)
+  local threshold = start_index or 1
   for _, intervention in ipairs(self.interventions) do
     local itype = intervention.type
-    if itype == "swap" or itype == "delay" or itype == "remove" then
+    local index = intervention.index or 1
+    if (itype == "swap" or itype == "delay" or itype == "remove") and index >= threshold then
       return true
     end
   end

--- a/tests/unit/timeline_manager_test.lua
+++ b/tests/unit/timeline_manager_test.lua
@@ -94,4 +94,34 @@ function suite.test_recalculate_from_preserves_actor_slot_for_suffix_delay()
   )
 end
 
+---@return nil
+function suite.test_actor_slot_intervention_detects_cross_boundary_swap_and_delay()
+  local manager = create_fixture()
+  manager.interventions = {
+    {type = "swap", index = 2, a = 2, b = 5},
+    {type = "delay", index = 1, to_index = 4},
+  }
+
+  TestHelper.assert_true(
+    manager:_has_actor_slot_intervention_from(4),
+    "시작 인덱스 이전에서 시작해도 suffix까지 닿는 swap/delay는 actor-slot 개입으로 유지되어야 합니다."
+  )
+end
+
+---@return nil
+function suite.test_recalculate_from_preserves_actor_slot_for_cross_boundary_swap()
+  local manager, calls = create_fixture()
+  manager.interventions = {
+    {type = "swap", index = 2, a = 2, b = 5},
+  }
+
+  manager:_recalculate_from(4)
+
+  TestHelper.assert_equal(#calls, 1, "재계산 호출이 한 번 발생해야 합니다.")
+  TestHelper.assert_true(
+    calls[1].preserve_actor_slots,
+    "교차 경계 swap은 suffix 재계산에서도 actor-slot 보존을 유지해야 합니다."
+  )
+end
+
 return suite

--- a/tests/unit/timeline_manager_test.lua
+++ b/tests/unit/timeline_manager_test.lua
@@ -124,4 +124,33 @@ function suite.test_recalculate_from_preserves_actor_slot_for_cross_boundary_swa
   )
 end
 
+---@return nil
+function suite.test_actor_slot_intervention_keeps_remove_for_later_suffix_recalc()
+  local manager = create_fixture()
+  manager.interventions = {
+    {type = "remove", index = 1},
+  }
+
+  TestHelper.assert_true(
+    manager:_has_actor_slot_intervention_from(3),
+    "앞쪽 remove는 이후 suffix 재계산에서도 actor-slot 보존을 유지해야 합니다."
+  )
+end
+
+---@return nil
+function suite.test_recalculate_from_preserves_actor_slot_after_prefix_remove()
+  local manager, calls = create_fixture()
+  manager.interventions = {
+    {type = "remove", index = 1},
+  }
+
+  manager:_recalculate_from(3)
+
+  TestHelper.assert_equal(#calls, 1, "재계산 호출이 한 번 발생해야 합니다.")
+  TestHelper.assert_true(
+    calls[1].preserve_actor_slots,
+    "앞쪽 remove 이후의 suffix 재계산은 actor-slot 보존을 유지해야 합니다."
+  )
+end
+
 return suite

--- a/tests/unit/timeline_manager_test.lua
+++ b/tests/unit/timeline_manager_test.lua
@@ -1,0 +1,97 @@
+local TestHelper = require("tests.test_helper")
+local TimelineManager = require("src.combat.timeline_manager")
+
+local suite = {}
+
+---@return TimelineManager, table
+local function create_fixture()
+  local calls = {}
+  local prediction_engine = {
+    recalculate_with = function(_, hero, enemies, timeline, start_index, opts)
+      calls[#calls + 1] = {
+        hero = hero,
+        enemies = enemies,
+        timeline = timeline,
+        start_index = start_index,
+        preserve_actor_slots = opts and opts.preserve_actor_slots or false,
+      }
+      return timeline
+    end,
+  }
+  local manager = TimelineManager:new(prediction_engine)
+  manager.hero = {id = "hero"}
+  manager.enemies = {{id = "enemy"}}
+  manager.timeline = {
+    {
+      slot_token = 1,
+      get_source_type = function()
+        return "hero"
+      end,
+    },
+    {
+      slot_token = 2,
+      get_source_type = function()
+        return "enemy"
+      end,
+    },
+    {
+      slot_token = 3,
+      get_source_type = function()
+        return "hero"
+      end,
+    },
+  }
+  return manager, calls
+end
+
+---@return nil
+function suite.test_actor_slot_intervention_only_counts_suffix_changes()
+  local manager = create_fixture()
+  manager.interventions = {
+    {type = "delay", index = 1},
+    {type = "modify", index = 3},
+  }
+
+  TestHelper.assert_false(
+    manager:_has_actor_slot_intervention_from(2),
+    "시작 인덱스 이전 조작만 있으면 actor-slot 보존을 강제하면 안 됩니다."
+  )
+  TestHelper.assert_true(
+    manager:_has_actor_slot_intervention_from(1),
+    "suffix 안쪽의 actor-slot 조작은 여전히 감지되어야 합니다."
+  )
+end
+
+---@return nil
+function suite.test_recalculate_from_disables_actor_slot_preserve_for_prefix_only_changes()
+  local manager, calls = create_fixture()
+  manager.interventions = {
+    {type = "delay", index = 1},
+  }
+
+  manager:_recalculate_from(3)
+
+  TestHelper.assert_equal(#calls, 1, "재계산 호출이 한 번 발생해야 합니다.")
+  TestHelper.assert_false(
+    calls[1].preserve_actor_slots,
+    "시작 인덱스 이전 actor-slot 조작만 있으면 suffix 재계산은 actor-slot을 고정하지 않아야 합니다."
+  )
+end
+
+---@return nil
+function suite.test_recalculate_from_preserves_actor_slot_for_suffix_delay()
+  local manager, calls = create_fixture()
+  manager.interventions = {
+    {type = "delay", index = 3},
+  }
+
+  manager:_recalculate_from(3)
+
+  TestHelper.assert_equal(#calls, 1, "재계산 호출이 한 번 발생해야 합니다.")
+  TestHelper.assert_true(
+    calls[1].preserve_actor_slots,
+    "suffix에 actor-slot 조작이 있으면 기존 보존 동작을 유지해야 합니다."
+  )
+end
+
+return suite


### PR DESCRIPTION
## 변경 내용
- `TimelineManager:_has_actor_slot_intervention_from()`가 `start_index` 이전의 `swap`/`delay`/`remove`를 suffix 재계산 근거로 보지 않도록 수정했습니다.
- suffix 앞쪽 조작만 있을 때 `preserve_actor_slots=false`가 전달되는 회귀 테스트를 추가했습니다.
- suffix 내부 조작은 기존처럼 actor-slot 보존이 유지되는 테스트도 함께 추가했습니다.

## 검증
- `./scripts/run_tests.sh` 통과
- `./scripts/check_love.sh` 통과

## 관련 이슈
- closes #50

## 구현 경로
- chosen route: `direct-impl`
- judge artifact: `.codex-workflows/github-issue-impl-pr/issue-50/judge-route.json`
- `ralplan`: not used
- `ralph`: not used

## 문서 동기화
- 문서 변경 불필요: 전투 타임라인 내부 재계산 조건만 수정되어 사용자/아키텍처 문서 서술은 변하지 않습니다.