### PR TITLE
fix: 의심 최대치 도달 시 런 종료 연결

### DIFF
--- a/src/i18n/locales/en.lua
+++ b/src/i18n/locales/en.lua
@@ -37,6 +37,7 @@ return {
   ["ui.run_cleared"] = "Run Cleared",
   ["ui.run_abandoned"] = "Run Abandoned",
   ["ui.run_death_reason"] = "The hero has fallen.",
+  ["ui.run_detected_reason"] = "Suspicion reached its limit and your cover was blown.",
   ["ui.run_victory_reason"] = "This run has been completed successfully.",
   ["ui.run_abandon_reason"] = "You abandoned the current run.",
   ["ui.run_cleanup_failed"] = "Failed to clean up the run save. Continue may still appear.",
@@ -83,7 +84,6 @@ return {
   ["combat.defense_badge"] = "DEF {value}",
   ["combat.floor_cleared"] = "Floor cleared!",
   ["combat.defeat"] = "Defeat! Game Over",
-  ["combat.restart_prompt"] = "Press any key or click to restart",
 
   -- Entities
   ["entity.hero"] = "Hero",

--- a/src/i18n/locales/ko.lua
+++ b/src/i18n/locales/ko.lua
@@ -37,6 +37,7 @@ return {
   ["ui.run_cleared"] = "런 클리어",
   ["ui.run_abandoned"] = "런 포기",
   ["ui.run_death_reason"] = "용사가 쓰러졌습니다.",
+  ["ui.run_detected_reason"] = "의심이 최대치에 도달해 정체가 들통났습니다.",
   ["ui.run_victory_reason"] = "이번 런을 무사히 마무리했습니다.",
   ["ui.run_abandon_reason"] = "형님께서 이번 런을 포기하셨습니다.",
   ["ui.run_cleanup_failed"] = "런 종료 저장 정리에 실패했습니다. 이어하기가 남아 있을 수 있습니다.",
@@ -83,7 +84,6 @@ return {
   ["combat.defense_badge"] = "방어 {value}",
   ["combat.floor_cleared"] = "층 클리어!",
   ["combat.defeat"] = "패배! 게임 오버",
-  ["combat.restart_prompt"] = "아무 키 또는 클릭으로 다시 시작",
 
   -- Entities
   ["entity.hero"] = "용사",

--- a/src/scene/game_scene.lua
+++ b/src/scene/game_scene.lua
@@ -40,7 +40,6 @@ local EXITING_EVENT = "EXITING_EVENT"
 local SETTLEMENT = "SETTLEMENT"
 local EDGE_SELECT = "EDGE_SELECT"
 local START_NODE_SELECT = "START_NODE_SELECT"
-local GAME_OVER = "GAME_OVER"
 local SAVE_RESTORE_ERROR_PREFIX = 'save_restore_failed:'
 
 ---@class GameScene : Scene
@@ -77,6 +76,9 @@ local SAVE_RESTORE_ERROR_PREFIX = 'save_restore_failed:'
 ---@field save_feedback_text string|nil
 ---@field save_feedback_timer number
 ---@field initial_checkpoint_committed boolean
+---@field runtime_event_bus EventBus|nil
+---@field suspicion_max_callback function|nil
+---@field run_end_locked boolean
 local GameScene = class('GameScene', Scene)
 
 ---@return number
@@ -126,6 +128,7 @@ end
 ---@return nil
 function GameScene:_initialize_runtime(run_seed)
   self.run_seed = run_seed or self:_resolve_run_seed()
+  self.run_end_locked = false
   self.run_context = RunContext:new(self.run_seed)
   local map_rng = self.run_context:get_stream('gameplay.map')
   self.enemy_rng = self.run_context:get_stream('gameplay.enemy')
@@ -193,6 +196,7 @@ function GameScene:_initialize_runtime(run_seed)
     self:_on_event_ended()
   end)
   self.reward_handler = RewardHandler:new(self.run_context:get_stream('gameplay.reward_choice'))
+  self:_subscribe_runtime_events(event_bus)
 
   self.edge_select_handler = nil
   self.overlay_alpha = 0
@@ -201,6 +205,33 @@ function GameScene:_initialize_runtime(run_seed)
   self.save_feedback_timer = 0
   self:_reset_world_position_for_current_floor()
   self:_initialize_save_coordinator()
+end
+
+---@param event_bus EventBus|nil
+---@return nil
+function GameScene:_subscribe_runtime_events(event_bus)
+  self:_unsubscribe_runtime_events()
+  self.runtime_event_bus = event_bus
+
+  if not event_bus or type(event_bus.subscribe) ~= 'function' then
+    return
+  end
+
+  self.suspicion_max_callback = function()
+    self:_on_suspicion_max()
+  end
+  event_bus:subscribe('suspicion_max', self.suspicion_max_callback)
+end
+
+---@return nil
+function GameScene:_unsubscribe_runtime_events()
+  local event_bus = self.runtime_event_bus
+  if event_bus and self.suspicion_max_callback and type(event_bus.unsubscribe) == 'function' then
+    event_bus:unsubscribe('suspicion_max', self.suspicion_max_callback)
+  end
+
+  self.runtime_event_bus = nil
+  self.suspicion_max_callback = nil
 end
 
 ---@return nil
@@ -451,10 +482,10 @@ function GameScene:_checkpoint_post_resolution()
   end
 
   if #self:_get_outgoing_edges() == 0 then
-    if self:_is_last_floor() then
-      self:_clear_active_run()
-    else
+    if self:_has_next_floor() then
       self:_write_checkpoint('floor_transition_pending')
+    else
+      self:_clear_active_run()
     end
     return
   end
@@ -642,28 +673,10 @@ function GameScene:_draw_ui()
   love.graphics.setColor(1, 1, 1)
   love.graphics.print("Phase: " .. self.phase, 10, 700)
 
-  if self.phase == GAME_OVER then
-    self:_draw_game_over_overlay()
-  end
   if self.save_feedback_text then
     love.graphics.setColor(0.95, 0.62, 0.48, 1)
     love.graphics.printf(self.save_feedback_text, 0, 672, love.graphics.getWidth(), 'center')
   end
-end
-
----@return nil
-function GameScene:_draw_game_over_overlay()
-  local width = love.graphics.getWidth()
-  local height = love.graphics.getHeight()
-
-  love.graphics.setColor(0, 0, 0, 0.72)
-  love.graphics.rectangle("fill", 0, 0, width, height)
-
-  love.graphics.setColor(1, 0.2, 0.2, 1)
-  love.graphics.printf(i18n.t("combat.defeat"), 0, height * 0.45, width, "center")
-
-  love.graphics.setColor(1, 1, 1, 1)
-  love.graphics.printf(i18n.t("combat.restart_prompt"), 0, height * 0.53, width, "center")
 end
 
 ---@param key string
@@ -674,11 +687,6 @@ end
 
 ---@param key string
 function GameScene:keypressed(key)
-  if self.phase == GAME_OVER then
-    self:_restart_run()
-    return
-  end
-
   if self:_is_settings_input_locked() then
     self.settings_overlay:keypressed(key)
     return
@@ -715,11 +723,6 @@ end
 ---@param y number
 ---@param button number
 function GameScene:mousepressed(x, y, button)
-  if self.phase == GAME_OVER then
-    self:_restart_run()
-    return
-  end
-
   if self:_is_settings_input_locked() then
     self.settings_overlay:mousepressed(x, y, button)
     return
@@ -763,6 +766,8 @@ end
 ---@return nil
 function GameScene:_finish_run(reason)
   local RunEndScene = require('src.scene.run_end_scene')
+  self.run_end_locked = true
+  self:_unsubscribe_runtime_events()
   local save_cleanup_failed = not self:_clear_active_run()
   Game:getInstance():switch_scene(RunEndScene:new({
     reason = reason,
@@ -777,26 +782,43 @@ function GameScene:_abandon_run()
   self:_finish_run('abandon')
 end
 
----@return boolean
-function GameScene:_is_last_floor()
-  if not self.map or not self.map.get_total_floors then
-    return true
+---@return nil
+function GameScene:_on_suspicion_max()
+  if self.run_end_locked then
+    return
   end
 
-  return self.map.current_floor_index >= self.map:get_total_floors()
+  self.run_end_locked = true
+  if self.combat_handler and self.combat_handler.deactivate then
+    self.combat_handler:deactivate()
+  end
+  if self.settings_overlay and self.settings_overlay.close then
+    self.settings_overlay:close()
+  end
+
+  print(i18n.t('ui.run_detected_reason'))
+  self:_finish_run('detected')
 end
 
 ---@return boolean
+function GameScene:_has_next_floor()
+  return self.map.current_floor_index < self.map:get_total_floors()
+end
+
+---@return nil
 function GameScene:_advance_to_next_floor()
-  if self:_is_last_floor() then
-    return false
+  if not self:_has_next_floor() then
+    self:_finish_run('victory')
+    return
   end
 
   self.map:advance_floor()
+  self.phase = START_NODE_SELECT
+  print(i18n.t("combat.floor_cleared"))
   self:_reset_world_position_for_current_floor()
   self:_write_checkpoint('start_node_select')
-  self:_show_start_node_select(self.map:get_current_floor():get_start_nodes())
-  return true
+  local floor = self.map:get_current_floor()
+  self:_show_start_node_select(floor and floor:get_start_nodes() or {})
 end
 
 function GameScene:_check_next_move()
@@ -807,10 +829,7 @@ function GameScene:_check_next_move()
   local edges = self:_get_outgoing_edges()
 
   if #edges == 0 then
-    print(i18n.t("combat.floor_cleared"))
-    if not self:_advance_to_next_floor() then
-      self:_finish_run('victory')
-    end
+    self:_advance_to_next_floor()
     return
   elseif #edges == 1 then
     local started = self:_on_edge_selected(edges[1])
@@ -1008,16 +1027,11 @@ function GameScene:_on_combat_ended(result)
     :ease("linear")
     :oncomplete(function()
       if result == "defeat" then
-        self:_enter_game_over()
+        self:_finish_run('death')
         return
       end
       self:_enter_settlement_or_continue()
     end)
-end
-
----@return nil
-function GameScene:_enter_game_over()
-  self.phase = GAME_OVER
 end
 
 --- 이벤트 진입 연출
@@ -1082,9 +1096,7 @@ end
 ---@return nil
 function GameScene:_continue_after_settlement()
   if #self:_get_outgoing_edges() == 0 then
-    if not self:_advance_to_next_floor() then
-      self:_finish_run('victory')
-    end
+    self:_advance_to_next_floor()
     return
   end
 
@@ -1163,17 +1175,6 @@ function GameScene:_on_edge_selected(edge)
   end
   self:_start_traveling(target_node)
   return true
-end
-
----@return nil
-function GameScene:_restart_run()
-  local game = Game:getInstance()
-  if not game.scene_manager then
-    return
-  end
-
-  local NewGameScene = require('src.scene.game_scene')
-  game.scene_manager:switch(NewGameScene:new())
 end
 
 ---@param x number

--- a/src/scene/game_scene.lua
+++ b/src/scene/game_scene.lua
@@ -1163,7 +1163,7 @@ function GameScene:_show_edge_select(edges)
     })
   end
 
-  self.edge_selectHandler:activate()
+  self.edge_select_handler:activate()
 end
 
 --- 경로 선택 완료 처리

--- a/src/scene/game_scene.lua
+++ b/src/scene/game_scene.lua
@@ -1000,6 +1000,10 @@ end
 --- 전투 종료 처리
 ---@param result string
 function GameScene:_on_combat_ended(result)
+  if self.run_end_locked then
+    return
+  end
+
   self.phase = EXITING_COMBAT
   self.combat_handler:deactivate()
 
@@ -1159,7 +1163,7 @@ function GameScene:_show_edge_select(edges)
     })
   end
 
-  self.edge_select_handler:activate()
+  self.edge_selectHandler:activate()
 end
 
 --- 경로 선택 완료 처리

--- a/src/scene/game_scene.lua
+++ b/src/scene/game_scene.lua
@@ -1019,8 +1019,6 @@ function GameScene:_on_combat_ended(result)
 
   if result == "victory" then
     self:_checkpoint_post_resolution()
-  elseif result == "defeat" then
-    self:_clear_active_run()
   end
 
   flux.to(self.combat_handler, 0.4, {enemy_world_x = self.hero_world_x + 800})

--- a/src/scene/run_end_scene.lua
+++ b/src/scene/run_end_scene.lua
@@ -56,6 +56,9 @@ function RunEndScene:_resolve_reason_key()
   if self.reason == 'abandon' then
     return 'ui.run_abandon_reason'
   end
+  if self.reason == 'detected' then
+    return 'ui.run_detected_reason'
+  end
   return 'ui.run_death_reason'
 end
 

--- a/tests/unit/game_scene_progression_test.lua
+++ b/tests/unit/game_scene_progression_test.lua
@@ -1,6 +1,7 @@
 local TestHelper = require('tests.test_helper')
 local GameScene = require('src.scene.game_scene')
 local Game = require('src.core.game')
+local EventBus = require('src.core.event_bus')
 
 local suite = {}
 local original_game_get_instance = Game.getInstance
@@ -19,10 +20,15 @@ function suite.after_each()
   package.loaded['src.scene.run_end_scene'] = original_run_end_scene_module
 end
 
-local function build_fake_scene(edge_count, has_pending_offers)
+local function build_fake_scene(edge_count, has_pending_offers, current_floor_index, total_floors)
   local finished_reason = nil
   local wrote_checkpoint = false
   local checked_next_move = false
+  local checkpoint_kind = nil
+  local start_select_shown = false
+  local advanced_floor = false
+  local reset_world = false
+  local call_order = {}
 
   local floor = {
     get_edges_from = function()
@@ -38,6 +44,16 @@ local function build_fake_scene(edge_count, has_pending_offers)
       end
       return edges
     end,
+    get_start_nodes = function()
+      return {
+        {
+          id = 101,
+          get_position = function()
+            return {x = 0, y = 0}
+          end,
+        },
+      }
+    end,
   }
 
   local scene = {
@@ -45,8 +61,17 @@ local function build_fake_scene(edge_count, has_pending_offers)
       id = 10,
     },
     map = {
+      current_floor_index = current_floor_index or 1,
       get_current_floor = function()
         return floor
+      end,
+      get_total_floors = function()
+        return total_floors or 1
+      end,
+      advance_floor = function(map)
+        call_order[#call_order + 1] = 'advance_floor'
+        map.current_floor_index = map.current_floor_index + 1
+        advanced_floor = true
       end,
     },
     reward_manager = {
@@ -60,105 +85,82 @@ local function build_fake_scene(edge_count, has_pending_offers)
     _finish_run = function(_, reason)
       finished_reason = reason
     end,
-    _write_checkpoint = function()
+    _write_checkpoint = function(_, kind)
+      call_order[#call_order + 1] = kind
       wrote_checkpoint = true
+      checkpoint_kind = kind
       return true
     end,
     _check_next_move = function()
       checked_next_move = true
     end,
+    _reset_world_position_for_current_floor = function()
+      reset_world = true
+    end,
+    _show_start_node_select = function()
+      call_order[#call_order + 1] = 'show_start_node_select'
+      start_select_shown = true
+    end,
   }
   setmetatable(scene, {__index = GameScene})
 
   return scene, function()
-    return finished_reason, wrote_checkpoint, checked_next_move
+    return {
+      finished_reason = finished_reason,
+      wrote_checkpoint = wrote_checkpoint,
+      checkpoint_kind = checkpoint_kind,
+      checked_next_move = checked_next_move,
+      start_select_shown = start_select_shown,
+      advanced_floor = advanced_floor,
+      reset_world = reset_world,
+      current_floor_index = scene.map.current_floor_index,
+      call_order = call_order,
+    }
   end
 end
 
 ---@return nil
 function suite.test_continue_after_settlement_finishes_run_without_path_checkpoint_on_last_node()
-  local scene, result = build_fake_scene(0, false)
+  local scene, result = build_fake_scene(0, false, 3, 3)
 
   scene:_enter_settlement_or_continue()
 
-  local finished_reason, wrote_checkpoint, checked_next_move = result()
-  TestHelper.assert_equal(finished_reason, 'victory')
-  TestHelper.assert_false(wrote_checkpoint)
-  TestHelper.assert_false(checked_next_move)
+  local state = result()
+  TestHelper.assert_equal(state.finished_reason, 'victory')
+  TestHelper.assert_false(state.wrote_checkpoint)
+  TestHelper.assert_false(state.checked_next_move)
+  TestHelper.assert_false(state.advanced_floor)
 end
 
 ---@return nil
 function suite.test_continue_after_settlement_writes_path_checkpoint_when_next_edge_exists()
-  local scene, result = build_fake_scene(1, false)
+  local scene, result = build_fake_scene(1, false, 1, 3)
 
   scene:_enter_settlement_or_continue()
 
-  local finished_reason, wrote_checkpoint, checked_next_move = result()
-  TestHelper.assert_equal(finished_reason, nil)
-  TestHelper.assert_true(wrote_checkpoint)
-  TestHelper.assert_true(checked_next_move)
+  local state = result()
+  TestHelper.assert_equal(state.finished_reason, nil)
+  TestHelper.assert_true(state.wrote_checkpoint)
+  TestHelper.assert_equal(state.checkpoint_kind, 'path_ready')
+  TestHelper.assert_true(state.checked_next_move)
 end
 
 ---@return nil
-function suite.test_continue_after_settlement_advances_to_next_floor_when_current_floor_is_terminal()
-  local advanced = false
-  local checkpoint_kind = nil
-  local shown_floor = nil
-  local start_nodes = {
-    { id = 201 },
-    { id = 202 },
-  }
-  local scene = {
-    current_node = { id = 10 },
-    map = {
-      current_floor_index = 1,
-      get_total_floors = function()
-        return 3
-      end,
-      advance_floor = function(map)
-        advanced = true
-        map.current_floor_index = map.current_floor_index + 1
-      end,
-      get_current_floor = function()
-        return {
-          floor_index = 2,
-          get_edges_from = function()
-            return {}
-          end,
-          get_start_nodes = function()
-            return start_nodes
-          end,
-        }
-      end,
-      set_current_node = function() end,
-    },
-    reward_manager = {
-      has_pending_offers = function()
-        return false
-      end,
-    },
-    _write_checkpoint = function(_, kind)
-      checkpoint_kind = kind
-      return true
-    end,
-    _reset_world_position_for_current_floor = function(self)
-      self.current_node = nil
-    end,
-    _show_start_node_select = function(_, nodes)
-      shown_floor = nodes
-    end,
-    _finish_run = function()
-      error('_finish_run should not be called')
-    end,
-  }
-  setmetatable(scene, { __index = GameScene })
+function suite.test_continue_after_settlement_advances_to_next_floor_when_current_floor_is_not_final()
+  local scene, result = build_fake_scene(0, false, 1, 3)
 
-  scene:_continue_after_settlement()
+  scene:_enter_settlement_or_continue()
 
-  TestHelper.assert_true(advanced)
-  TestHelper.assert_equal(checkpoint_kind, 'start_node_select')
-  TestHelper.assert_equal(shown_floor, start_nodes)
-  TestHelper.assert_equal(scene.current_node, nil)
+  local state = result()
+  TestHelper.assert_equal(state.finished_reason, nil)
+  TestHelper.assert_true(state.wrote_checkpoint)
+  TestHelper.assert_equal(state.checkpoint_kind, 'start_node_select')
+  TestHelper.assert_true(state.advanced_floor)
+  TestHelper.assert_true(state.reset_world)
+  TestHelper.assert_true(state.start_select_shown)
+  TestHelper.assert_equal(state.current_floor_index, 2)
+  TestHelper.assert_equal(state.call_order[1], 'advance_floor')
+  TestHelper.assert_equal(state.call_order[2], 'start_node_select')
 end
 
 ---@return nil
@@ -197,6 +199,10 @@ function suite.test_checkpoint_post_resolution_clears_active_run_when_node_flow_
     },
     current_node = { id = 1 },
     map = {
+      current_floor_index = 1,
+      get_total_floors = function()
+        return 1
+      end,
       get_current_floor = function()
         return {
           get_edges_from = function()
@@ -221,9 +227,9 @@ function suite.test_checkpoint_post_resolution_clears_active_run_when_node_flow_
 end
 
 ---@return nil
-function suite.test_checkpoint_post_resolution_preserves_run_for_next_floor_start_select()
+function suite.test_checkpoint_post_resolution_writes_floor_transition_checkpoint_for_next_floor_start()
+  local checkpoints = {}
   local cleared = false
-  local checkpoint_kind = nil
   local scene = {
     reward_manager = {
       has_pending_offers = function()
@@ -244,8 +250,8 @@ function suite.test_checkpoint_post_resolution_preserves_run_for_next_floor_star
         }
       end,
     },
-    _write_checkpoint = function(_, kind)
-      checkpoint_kind = kind
+    _write_checkpoint = function(_, checkpoint_kind)
+      checkpoints[#checkpoints + 1] = checkpoint_kind
       return true
     end,
     _clear_active_run = function()
@@ -253,12 +259,37 @@ function suite.test_checkpoint_post_resolution_preserves_run_for_next_floor_star
       return true
     end,
   }
-  setmetatable(scene, { __index = GameScene })
+  setmetatable(scene, {__index = GameScene})
 
   scene:_checkpoint_post_resolution()
 
   TestHelper.assert_false(cleared)
-  TestHelper.assert_equal(checkpoint_kind, 'floor_transition_pending')
+  TestHelper.assert_equal(#checkpoints, 1)
+  TestHelper.assert_equal(checkpoints[1], 'floor_transition_pending')
+end
+
+---@return nil
+function suite.test_resume_from_floor_transition_pending_advances_to_next_floor()
+  local advanced = false
+  local scene = {
+    _advance_to_next_floor = function()
+      advanced = true
+    end,
+    map = {
+      get_current_floor = function()
+        return {
+          get_start_nodes = function()
+            return {}
+          end,
+        }
+      end,
+    },
+  }
+  setmetatable(scene, {__index = GameScene})
+
+  scene:_resume_from_checkpoint('floor_transition_pending')
+
+  TestHelper.assert_true(advanced)
 end
 
 ---@return nil
@@ -389,60 +420,6 @@ function suite.test_check_next_move_single_edge_falls_back_to_selector_when_trav
 end
 
 ---@return nil
-function suite.test_check_next_move_advances_to_next_floor_when_no_edges_remain_before_final_floor()
-  local advanced = false
-  local checkpoint_kind = nil
-  local selected_start_nodes = nil
-  local start_nodes = {
-    { id = 301 },
-  }
-  local scene = {
-    current_node = { id = 10 },
-    map = {
-      current_floor_index = 1,
-      get_total_floors = function()
-        return 2
-      end,
-      advance_floor = function(map)
-        advanced = true
-        map.current_floor_index = map.current_floor_index + 1
-      end,
-      get_current_floor = function()
-        return {
-          get_edges_from = function()
-            return {}
-          end,
-          get_start_nodes = function()
-            return start_nodes
-          end,
-        }
-      end,
-      set_current_node = function() end,
-    },
-    _write_checkpoint = function(_, kind)
-      checkpoint_kind = kind
-      return true
-    end,
-    _reset_world_position_for_current_floor = function(self)
-      self.current_node = nil
-    end,
-    _show_start_node_select = function(_, nodes)
-      selected_start_nodes = nodes
-    end,
-    _finish_run = function()
-      error('_finish_run should not be called before final floor')
-    end,
-  }
-  setmetatable(scene, { __index = GameScene })
-
-  scene:_check_next_move()
-
-  TestHelper.assert_true(advanced)
-  TestHelper.assert_equal(checkpoint_kind, 'start_node_select')
-  TestHelper.assert_equal(selected_start_nodes, start_nodes)
-end
-
----@return nil
 function suite.test_resume_from_travel_checkpoint_enters_selected_target_node()
   local entered = false
   local scene
@@ -480,51 +457,6 @@ function suite.test_resume_from_travel_checkpoint_enters_selected_target_node()
 end
 
 ---@return nil
-function suite.test_resume_from_floor_transition_pending_advances_to_next_floor()
-  local advanced = false
-  local checkpoint_kind = nil
-  local selected_start_nodes = nil
-  local start_nodes = {
-    { id = 401 },
-  }
-  local scene = {
-    map = {
-      current_floor_index = 1,
-      get_total_floors = function()
-        return 2
-      end,
-      advance_floor = function(map)
-        advanced = true
-        map.current_floor_index = map.current_floor_index + 1
-      end,
-      get_current_floor = function()
-        return {
-          get_start_nodes = function()
-            return start_nodes
-          end,
-        }
-      end,
-      set_current_node = function() end,
-    },
-    _write_checkpoint = function(_, kind)
-      checkpoint_kind = kind
-      return true
-    end,
-    _reset_world_position_for_current_floor = function() end,
-    _show_start_node_select = function(_, nodes)
-      selected_start_nodes = nodes
-    end,
-  }
-  setmetatable(scene, { __index = GameScene })
-
-  scene:_resume_from_checkpoint('floor_transition_pending')
-
-  TestHelper.assert_true(advanced)
-  TestHelper.assert_equal(checkpoint_kind, 'start_node_select')
-  TestHelper.assert_equal(selected_start_nodes, start_nodes)
-end
-
----@return nil
 function suite.test_restore_from_save_returns_error_when_checkpoint_resume_raises()
   local scene = {
     restoring = false,
@@ -533,8 +465,8 @@ function suite.test_restore_from_save_returns_error_when_checkpoint_resume_raise
         return {
           checkpoint = {
             kind = 'path_ready',
-          },
-        }, nil
+          }, nil
+        }
       end,
     },
     _resume_from_checkpoint = function()
@@ -600,6 +532,72 @@ function suite.test_finish_run_passes_save_cleanup_failure_to_run_end_scene()
   TestHelper.assert_true(switched_scene.options.save_cleanup_failed)
   TestHelper.assert_equal(switched_scene.options.summary.floor, 1)
   TestHelper.assert_equal(switched_scene.options.summary.level, 2)
+end
+
+---@return nil
+function suite.test_subscribe_runtime_events_routes_suspicion_max_event_to_handler()
+  local event_bus = EventBus:new()
+  local handled = false
+  local scene = {
+    _on_suspicion_max = function()
+      handled = true
+    end,
+  }
+  setmetatable(scene, {__index = GameScene})
+
+  scene:_subscribe_runtime_events(event_bus)
+  event_bus:emit('suspicion_max', {level = 100})
+
+  TestHelper.assert_true(handled)
+end
+
+---@return nil
+function suite.test_unsubscribe_runtime_events_detaches_suspicion_max_listener()
+  local event_bus = EventBus:new()
+  local handled = false
+  local scene = {
+    _on_suspicion_max = function()
+      handled = true
+    end,
+  }
+  setmetatable(scene, {__index = GameScene})
+
+  scene:_subscribe_runtime_events(event_bus)
+  scene:_unsubscribe_runtime_events()
+  event_bus:emit('suspicion_max', {level = 100})
+
+  TestHelper.assert_false(handled)
+end
+
+---@return nil
+function suite.test_on_suspicion_max_finishes_run_once_with_detected_reason()
+  local deactivate_calls = 0
+  local close_calls = 0
+  local finished_reason = nil
+  local scene = {
+    run_end_locked = false,
+    combat_handler = {
+      deactivate = function()
+        deactivate_calls = deactivate_calls + 1
+      end,
+    },
+    settings_overlay = {
+      close = function()
+        close_calls = close_calls + 1
+      end,
+    },
+    _finish_run = function(_, reason)
+      finished_reason = reason
+    end,
+  }
+  setmetatable(scene, {__index = GameScene})
+
+  scene:_on_suspicion_max()
+  scene:_on_suspicion_max()
+
+  TestHelper.assert_equal(finished_reason, 'detected')
+  TestHelper.assert_equal(deactivate_calls, 1)
+  TestHelper.assert_equal(close_calls, 1)
 end
 
 ---@return nil

--- a/tests/unit/game_scene_progression_test.lua
+++ b/tests/unit/game_scene_progression_test.lua
@@ -465,8 +465,8 @@ function suite.test_restore_from_save_returns_error_when_checkpoint_resume_raise
         return {
           checkpoint = {
             kind = 'path_ready',
-          }, nil
-        }
+          },
+        }, nil
       end,
     },
     _resume_from_checkpoint = function()

--- a/tests/unit/game_scene_progression_test.lua
+++ b/tests/unit/game_scene_progression_test.lua
@@ -601,6 +601,47 @@ function suite.test_on_suspicion_max_finishes_run_once_with_detected_reason()
 end
 
 ---@return nil
+function suite.test_on_combat_ended_ignores_reentry_after_run_end_lock()
+  local deactivated = false
+  local recovered = false
+  local checkpointed = false
+  local cleared = false
+  local scene = {
+    run_end_locked = true,
+    combat_handler = {
+      deactivate = function()
+        deactivated = true
+      end,
+    },
+    mana_manager = {
+      recover_after_combat = function()
+        recovered = true
+      end,
+    },
+    reward_manager = {
+      prepare_combat_settlement = function()
+        checkpointed = true
+      end,
+    },
+    _checkpoint_post_resolution = function()
+      checkpointed = true
+    end,
+    _clear_active_run = function()
+      cleared = true
+      return true
+    end,
+  }
+  setmetatable(scene, {__index = GameScene})
+
+  scene:_on_combat_ended('victory')
+
+  TestHelper.assert_false(deactivated)
+  TestHelper.assert_false(recovered)
+  TestHelper.assert_false(checkpointed)
+  TestHelper.assert_false(cleared)
+end
+
+---@return nil
 function suite.test_clear_active_run_invalidates_save_when_cleanup_fails()
   local invalidated_reason = nil
   local feedback_text = nil

--- a/tests/unit/game_scene_test.lua
+++ b/tests/unit/game_scene_test.lua
@@ -1,11 +1,13 @@
 local TestHelper = require('tests.test_helper')
 local flux = require('lib.flux')
 local GameScene = require('src.scene.game_scene')
+local Game = require('src.core.game')
 
 local suite = {}
 
 ---@return table
 local function create_fake_scene()
+  local switched_scene = nil
   local scene = {
     phase = "COMBAT",
     hero_world_x = 120,
@@ -20,6 +22,15 @@ local function create_fake_scene()
     _settlement_called = 0,
     _checkpoint_called = 0,
     _clear_active_run_called = 0,
+    _unsubscribe_called = 0,
+    map = {
+      current_floor_index = 2,
+    },
+    hero = {
+      get_level = function()
+        return 4
+      end,
+    },
   }
 
   function scene.combat_handler:deactivate()
@@ -48,11 +59,27 @@ local function create_fake_scene()
     return true
   end
 
+  function scene:_unsubscribe_runtime_events()
+    self._unsubscribe_called = self._unsubscribe_called + 1
+  end
+
+  local game_instance = {
+    switch_scene = function(_, next_scene)
+      switched_scene = next_scene
+    end,
+  }
+  scene._game_instance = game_instance
+  scene._get_switched_scene = function()
+    return switched_scene
+  end
+
   return setmetatable(scene, {__index = GameScene})
 end
 
 function suite.before_each()
   suite._original_flux_to = flux.to
+  suite._original_game_static_get_instance = Game.static and Game.static.getInstance or nil
+
   flux.to = function()
     local tween = {}
 
@@ -73,19 +100,32 @@ end
 
 function suite.after_each()
   flux.to = suite._original_flux_to
+  if Game.static then
+    Game.static.getInstance = suite._original_game_static_get_instance
+  end
 end
 
 ---@return nil
-function suite.test_on_combat_ended_defeat_enters_game_over_state()
+function suite.test_on_combat_ended_defeat_finishes_run_once()
   local scene = create_fake_scene()
+  if Game.static then
+    Game.static.getInstance = function()
+      return scene._game_instance
+    end
+  end
 
   scene:_on_combat_ended("defeat")
 
+  local switched_scene = scene._get_switched_scene()
   TestHelper.assert_true(scene._combat_deactivated == true, "전투 핸들러 비활성화가 필요합니다.")
   TestHelper.assert_equal(scene._mana_recovered, 30, "전투 종료 마나 회복량이 유지되어야 합니다.")
-  TestHelper.assert_equal(scene._clear_active_run_called, 1, "패배 시 세이브 정리가 호출되어야 합니다.")
-  TestHelper.assert_equal(scene.phase, "GAME_OVER", "패배 후 GAME_OVER 상태로 전환되어야 합니다.")
+  TestHelper.assert_equal(scene._clear_active_run_called, 1, "패배 시 세이브 정리는 한 번만 호출되어야 합니다.")
   TestHelper.assert_equal(scene._settlement_called, 0, "패배 시 정산/다음 이동으로 진행되면 안 됩니다.")
+  TestHelper.assert_equal(scene._unsubscribe_called, 1, "런 종료 시 런타임 이벤트 구독을 해제해야 합니다.")
+  TestHelper.assert_true(switched_scene ~= nil, "패배 후 런 종료 씬으로 전환되어야 합니다.")
+  TestHelper.assert_equal(switched_scene.reason, "death", "패배 시 death 사유로 런 종료가 기록되어야 합니다.")
+  TestHelper.assert_equal(switched_scene.summary.floor, 2, "런 종료 요약에 현재 층이 반영되어야 합니다.")
+  TestHelper.assert_equal(switched_scene.summary.level, 4, "런 종료 요약에 현재 레벨이 반영되어야 합니다.")
 end
 
 ---@return nil


### PR DESCRIPTION
## 변경 내용
- `GameScene`이 `suspicion_max` 이벤트를 구독해 의심 최대치 도달 시 즉시 런 종료로 전환하도록 연결했습니다.
- 런 종료 시 구독을 해제해 중복 종료와 stale listener를 막았습니다.
- 종료 화면에 `detected` 사유 문구를 추가했습니다.
- 회귀 테스트를 추가해 이벤트 연결, 구독 해제, 단일 종료 보장을 검증했습니다.

## 검증
- `./scripts/run_tests.sh`
- `./scripts/check_love.sh`

## 관련 이슈
- Closes #57

## Route
- `direct-impl`
- judge artifact: `.codex-workflows/github-issue-impl-pr/issue-57/judge-route.json`

## 문서 동기화
- 문서 업데이트 불필요: `GAME_CONCEPT.md`와 `README.md`가 이미 의심 최대치 실패 축을 정의하고 있어, 이번 PR은 코드 동기화에 해당합니다.