### PR TITLE
fix: 이벤트 치사 피해 시 런 종료 연결

### DIFF
--- a/src/scene/game_scene.lua
+++ b/src/scene/game_scene.lua
@@ -1057,13 +1057,25 @@ end
 
 --- 이벤트 종료 처리
 function GameScene:_on_event_ended()
-  self:_checkpoint_post_resolution()
   self.phase = EXITING_EVENT
   self.event_handler:deactivate()
+
+  local hero_alive = true
+  if self.hero and self.hero.is_alive then
+    hero_alive = self.hero:is_alive()
+  end
+
+  if hero_alive then
+    self:_checkpoint_post_resolution()
+  end
 
   flux.to(self.event_handler, 0.3, {panel_alpha = 0, panel_y = -200})
     :ease("quadin")
     :oncomplete(function()
+      if self.hero and self.hero.is_alive and not self.hero:is_alive() then
+        self:_enter_game_over()
+        return
+      end
       self:_enter_settlement_or_continue()
     end)
 end

--- a/src/scene/game_scene.lua
+++ b/src/scene/game_scene.lua
@@ -1073,6 +1073,7 @@ function GameScene:_on_event_ended()
     :ease("quadin")
     :oncomplete(function()
       if self.hero and self.hero.is_alive and not self.hero:is_alive() then
+        self:_clear_active_run()
         self:_enter_game_over()
         return
       end

--- a/tests/unit/game_scene_progression_test.lua
+++ b/tests/unit/game_scene_progression_test.lua
@@ -611,6 +611,7 @@ function suite.test_on_event_ended_enters_game_over_on_lethal_event_damage()
   local checkpointed = false
   local entered_settlement = false
   local entered_game_over = false
+  local cleared_run = false
   local scene = {
     hero = {
       is_alive = function()
@@ -630,6 +631,10 @@ function suite.test_on_event_ended_enters_game_over_on_lethal_event_damage()
     _enter_settlement_or_continue = function()
       entered_settlement = true
     end,
+    _clear_active_run = function()
+      cleared_run = true
+      return true
+    end,
     _enter_game_over = function()
       entered_game_over = true
     end,
@@ -642,6 +647,7 @@ function suite.test_on_event_ended_enters_game_over_on_lethal_event_damage()
   TestHelper.assert_true(deactivated)
   TestHelper.assert_false(checkpointed)
   TestHelper.assert_false(entered_settlement)
+  TestHelper.assert_true(cleared_run)
   TestHelper.assert_true(entered_game_over)
 end
 
@@ -651,6 +657,7 @@ function suite.test_on_event_ended_preserves_existing_flow_when_hero_survives()
   local checkpointed = false
   local entered_settlement = false
   local entered_game_over = false
+  local cleared_run = false
   local scene = {
     hero = {
       is_alive = function()
@@ -670,6 +677,10 @@ function suite.test_on_event_ended_preserves_existing_flow_when_hero_survives()
     _enter_settlement_or_continue = function()
       entered_settlement = true
     end,
+    _clear_active_run = function()
+      cleared_run = true
+      return true
+    end,
     _enter_game_over = function()
       entered_game_over = true
     end,
@@ -682,6 +693,7 @@ function suite.test_on_event_ended_preserves_existing_flow_when_hero_survives()
   TestHelper.assert_true(deactivated)
   TestHelper.assert_true(checkpointed)
   TestHelper.assert_true(entered_settlement)
+  TestHelper.assert_false(cleared_run)
   TestHelper.assert_false(entered_game_over)
 end
 

--- a/tests/unit/game_scene_progression_test.lua
+++ b/tests/unit/game_scene_progression_test.lua
@@ -606,11 +606,11 @@ function suite.test_finish_run_passes_save_cleanup_failure_to_run_end_scene()
 end
 
 ---@return nil
-function suite.test_on_event_ended_finishes_run_on_lethal_event_damage()
+function suite.test_on_event_ended_enters_game_over_on_lethal_event_damage()
   local deactivated = false
   local checkpointed = false
   local entered_settlement = false
-  local finished_reason = nil
+  local entered_game_over = false
   local scene = {
     hero = {
       is_alive = function()
@@ -630,8 +630,8 @@ function suite.test_on_event_ended_finishes_run_on_lethal_event_damage()
     _enter_settlement_or_continue = function()
       entered_settlement = true
     end,
-    _finish_run = function(_, reason)
-      finished_reason = reason
+    _enter_game_over = function()
+      entered_game_over = true
     end,
   }
   setmetatable(scene, {__index = GameScene})
@@ -642,7 +642,7 @@ function suite.test_on_event_ended_finishes_run_on_lethal_event_damage()
   TestHelper.assert_true(deactivated)
   TestHelper.assert_false(checkpointed)
   TestHelper.assert_false(entered_settlement)
-  TestHelper.assert_equal(finished_reason, 'death')
+  TestHelper.assert_true(entered_game_over)
 end
 
 ---@return nil
@@ -650,7 +650,7 @@ function suite.test_on_event_ended_preserves_existing_flow_when_hero_survives()
   local deactivated = false
   local checkpointed = false
   local entered_settlement = false
-  local finished_reason = nil
+  local entered_game_over = false
   local scene = {
     hero = {
       is_alive = function()
@@ -670,8 +670,8 @@ function suite.test_on_event_ended_preserves_existing_flow_when_hero_survives()
     _enter_settlement_or_continue = function()
       entered_settlement = true
     end,
-    _finish_run = function(_, reason)
-      finished_reason = reason
+    _enter_game_over = function()
+      entered_game_over = true
     end,
   }
   setmetatable(scene, {__index = GameScene})
@@ -682,7 +682,7 @@ function suite.test_on_event_ended_preserves_existing_flow_when_hero_survives()
   TestHelper.assert_true(deactivated)
   TestHelper.assert_true(checkpointed)
   TestHelper.assert_true(entered_settlement)
-  TestHelper.assert_equal(finished_reason, nil)
+  TestHelper.assert_false(entered_game_over)
 end
 
 ---@return nil

--- a/tests/unit/game_scene_progression_test.lua
+++ b/tests/unit/game_scene_progression_test.lua
@@ -1,6 +1,7 @@
 local TestHelper = require('tests.test_helper')
 local GameScene = require('src.scene.game_scene')
 local Game = require('src.core.game')
+local flux = require('lib.flux')
 
 local suite = {}
 local original_game_get_instance = Game.getInstance
@@ -9,6 +10,7 @@ local original_run_end_scene_module = nil
 
 function suite.before_each()
   original_run_end_scene_module = package.loaded['src.scene.run_end_scene']
+  flux.tweens = {}
 end
 
 function suite.after_each()
@@ -17,6 +19,7 @@ function suite.after_each()
     Game.static.getInstance = original_game_static_get_instance
   end
   package.loaded['src.scene.run_end_scene'] = original_run_end_scene_module
+  flux.tweens = {}
 end
 
 local function build_fake_scene(edge_count, has_pending_offers)
@@ -600,6 +603,86 @@ function suite.test_finish_run_passes_save_cleanup_failure_to_run_end_scene()
   TestHelper.assert_true(switched_scene.options.save_cleanup_failed)
   TestHelper.assert_equal(switched_scene.options.summary.floor, 1)
   TestHelper.assert_equal(switched_scene.options.summary.level, 2)
+end
+
+---@return nil
+function suite.test_on_event_ended_finishes_run_on_lethal_event_damage()
+  local deactivated = false
+  local checkpointed = false
+  local entered_settlement = false
+  local finished_reason = nil
+  local scene = {
+    hero = {
+      is_alive = function()
+        return false
+      end,
+    },
+    event_handler = {
+      panel_alpha = 1,
+      panel_y = 0,
+      deactivate = function()
+        deactivated = true
+      end,
+    },
+    _checkpoint_post_resolution = function()
+      checkpointed = true
+    end,
+    _enter_settlement_or_continue = function()
+      entered_settlement = true
+    end,
+    _finish_run = function(_, reason)
+      finished_reason = reason
+    end,
+  }
+  setmetatable(scene, {__index = GameScene})
+
+  scene:_on_event_ended()
+  flux.update(1)
+
+  TestHelper.assert_true(deactivated)
+  TestHelper.assert_false(checkpointed)
+  TestHelper.assert_false(entered_settlement)
+  TestHelper.assert_equal(finished_reason, 'death')
+end
+
+---@return nil
+function suite.test_on_event_ended_preserves_existing_flow_when_hero_survives()
+  local deactivated = false
+  local checkpointed = false
+  local entered_settlement = false
+  local finished_reason = nil
+  local scene = {
+    hero = {
+      is_alive = function()
+        return true
+      end,
+    },
+    event_handler = {
+      panel_alpha = 1,
+      panel_y = 0,
+      deactivate = function()
+        deactivated = true
+      end,
+    },
+    _checkpoint_post_resolution = function()
+      checkpointed = true
+    end,
+    _enter_settlement_or_continue = function()
+      entered_settlement = true
+    end,
+    _finish_run = function(_, reason)
+      finished_reason = reason
+    end,
+  }
+  setmetatable(scene, {__index = GameScene})
+
+  scene:_on_event_ended()
+  flux.update(1)
+
+  TestHelper.assert_true(deactivated)
+  TestHelper.assert_true(checkpointed)
+  TestHelper.assert_true(entered_settlement)
+  TestHelper.assert_equal(finished_reason, nil)
 end
 
 ---@return nil


### PR DESCRIPTION
## 변경 내용
- 이벤트 종료 애니메이션 직전에 용사 생존 여부를 확인하도록 `GameScene:_on_event_ended()`를 보강했습니다.
- 이벤트 피해로 용사가 쓰러진 경우 체크포인트/정산 이동 대신 즉시 `GAME_OVER` 진입으로 전환합니다.
- 회귀 테스트를 추가해 치사 이벤트는 게임오버로, 비치사 이벤트는 기존 정산 흐름으로 유지되는지 검증했습니다.

## 검증
- `./scripts/run_tests.sh`
- `./scripts/check_love.sh`

## 관련 이슈
- Closes #63

## Route
- `direct-impl`
- judge artifact: `.codex-workflows/github-issue-impl-pr/issue-63/judge-route.json`

## 문서 동기화
- 문서 업데이트 불필요: 기존 문서는 전투 외 사망 경로 세부 전이를 설명하지 않았고, 이번 변경은 런 종료 동작을 코드와 이슈 관찰에 맞춰 보정하는 수준입니다.