### PR TITLE
docs(core): CLASS_DIAGRAM 관계 정정

### DIFF
--- a/CLASS_DIAGRAM.md
+++ b/CLASS_DIAGRAM.md
@@ -169,6 +169,8 @@ classDiagram
 
   EventManager --> Event
   Event --> Choice
+  Spell --> ManaManager
+  Spell --> SuspicionManager
 ```
 
 ## 6) 핸들러 / UI 계층
@@ -235,4 +237,4 @@ classDiagram
 ## 문서 메타
 
 - 문서 기준: `origin/main`
-- Last Updated: 2026-03-12
+- Last Updated: 2026-04-07

--- a/CLASS_DIAGRAM.md
+++ b/CLASS_DIAGRAM.md
@@ -169,9 +169,6 @@ classDiagram
 
   EventManager --> Event
   Event --> Choice
-
-  SpellBook --> ManaManager
-  Spell --> SuspicionManager
 ```
 
 ## 6) 핸들러 / UI 계층
@@ -200,6 +197,8 @@ classDiagram
 
   CombatHandler --> TimelineUI
   CombatHandler --> SpellBookOverlay
+  CombatHandler --> ManaManager
+  CombatHandler --> SuspicionManager
   EventHandler --> Button
   RewardHandler --> Button
   EdgeSelectHandler --> EdgeSelector
@@ -211,8 +210,6 @@ classDiagram
   SpellBookOverlay --|> UIElement
   EdgeSelector --|> UIElement
   Minimap --|> UIElement
-  MapOverlay --|> UIElement
-  SettingsOverlay --|> UIElement
 
   MainMenuScene --> SettingsOverlay
   GameScene --> CombatHandler


### PR DESCRIPTION
## 변경 내용
- `MapOverlay`, `SettingsOverlay`가 `UIElement`를 상속하는 것처럼 보이던 잘못된 화살표를 제거했습니다.
- `SpellBook -> ManaManager`, `Spell -> SuspicionManager` 직접 의존 화살표를 제거했습니다.
- 실제 조율 주체에 맞춰 `CombatHandler -> ManaManager`, `CombatHandler -> SuspicionManager` 관계를 추가했습니다.

## 검증
- `./scripts/run_tests.sh`
- `./scripts/check_love.sh`

## 관련 이슈
- Closes #51

## Route
- `direct-impl`
- judge artifact: `.codex-workflows/github-issue-impl-pr/issue-51/judge-route.json`

## 문서 동기화
- 추가 문서 업데이트 불필요: 이번 변경 자체가 `CLASS_DIAGRAM.md`를 현재 코드 기준으로 정정하는 작업입니다.