### PR TITLE
docs: UI 오버레이 계층 다이어그램 정정

### DIFF
--- a/.codex-workflows/github-issue-impl-pr/issue-66/handoff.md
+++ b/.codex-workflows/github-issue-impl-pr/issue-66/handoff.md
@@ -1,0 +1,21 @@
+# Impl Handoff
+
+- issue: #66
+- owner_repo: rlatndud9090/frdy
+- branch_name: codex/issue-66-class-diagram-ui-hierarchy
+- judge_route: direct-impl
+- ralplan_artifacts: none
+- ralph_artifacts: none
+- validation_commands:
+  - ./scripts/run_tests.sh
+  - ./scripts/check_love.sh
+  - ./scripts/check_artifact_guard.sh
+- validation_summary:
+  - ./scripts/run_tests.sh: 122 passed
+  - ./scripts/check_love.sh: success (`CHECK_LOVE_OK`)
+  - ./scripts/check_artifact_guard.sh: code/data/tests 변경 없음으로 guard skip
+- notes:
+  - detached HEAD에서 이슈 전용 브랜치를 새로 만들고 작업을 격리했습니다.
+  - LLM Wiki/artifact 규칙에 따라 branch scaffold를 먼저 생성했습니다.
+  - 실제 수정 대상은 `docs/wiki/systems/class-architecture.md`입니다.
+  - 루트 `CLASS_DIAGRAM.md`는 현재 포인터 문서이므로 수정 대상이 아니었습니다.

--- a/.codex-workflows/github-issue-impl-pr/issue-66/judge-raw.md
+++ b/.codex-workflows/github-issue-impl-pr/issue-66/judge-raw.md
@@ -1,0 +1,33 @@
+Issue #66 route judgement
+
+- scope is narrow and documentation-only
+- affected surface is one wiki diagram block
+- acceptance criteria are explicit from the issue body and current code
+- no design replanning or multi-file implementation loop is needed
+
+```json
+{
+  "kind": "issue_route_judgement",
+  "route": "direct-impl",
+  "confidence": "high",
+  "summary": "문서상 잘못된 UI 상속 화살표 두 줄을 현재 코드 기준으로 정정하는 국소 수정입니다.",
+  "reasons": [
+    "실제 코드에서 MapOverlay와 SettingsOverlay는 UIElement를 상속하지 않습니다.",
+    "위키 다이어그램 한 블록만 수정하면 현재 불일치를 해소할 수 있습니다.",
+    "필수 검증 리스크가 낮고 acceptance criteria가 선명합니다."
+  ],
+  "blocking_unknowns": [
+    "이슈 본문이 루트 CLASS_DIAGRAM.md를 지목하지만 현재 워크트리에서는 위키 문서가 실제 수정 대상입니다."
+  ],
+  "handoff_notes": [
+    "PR 범위는 문서와 artifact 상태 유지로 제한합니다.",
+    "main 머지 후 wiki_sync_status 후속 갱신 가능성을 artifact에 남깁니다."
+  ],
+  "signals": {
+    "scope_clarity": "high",
+    "surface_area": "single-file",
+    "verification_risk": "low",
+    "design_risk": "low"
+  }
+}
+```

--- a/.codex-workflows/github-issue-impl-pr/issue-66/judge-route.json
+++ b/.codex-workflows/github-issue-impl-pr/issue-66/judge-route.json
@@ -1,0 +1,24 @@
+{
+  "kind": "issue_route",
+  "route": "direct-impl",
+  "summary": "문서상 잘못된 UI 상속 화살표 두 줄을 현재 코드 기준으로 정정하는 국소 수정입니다.",
+  "confidence": "high",
+  "reasons": [
+    "실제 코드에서 MapOverlay와 SettingsOverlay는 UIElement를 상속하지 않습니다.",
+    "위키 다이어그램 한 블록만 수정하면 현재 불일치를 해소할 수 있습니다.",
+    "필수 검증 리스크가 낮고 acceptance criteria가 선명합니다."
+  ],
+  "blocking_unknowns": [
+    "이슈 본문이 루트 CLASS_DIAGRAM.md를 지목하지만 현재 워크트리에서는 위키 문서가 실제 수정 대상입니다."
+  ],
+  "handoff_notes": [
+    "PR 범위는 문서와 artifact 상태 유지로 제한합니다.",
+    "main 머지 후 wiki_sync_status 후속 갱신 가능성을 artifact에 남깁니다."
+  ],
+  "signals": {
+    "scope_clarity": "high",
+    "surface_area": "single-file",
+    "verification_risk": "low",
+    "design_risk": "low"
+  }
+}

--- a/.codex-workflows/github-next-issue-autopilot/issue-66-class-diagram-ui-hierarchy/handoff.md
+++ b/.codex-workflows/github-next-issue-autopilot/issue-66-class-diagram-ui-hierarchy/handoff.md
@@ -1,0 +1,10 @@
+# Autopilot Handoff
+
+- selected_issue: #66
+- impl_route: direct-impl
+- artifact_dir: docs/artifacts/codex-issue-66-class-diagram-ui-hierarchy
+- impl_run_dir: .codex-workflows/github-issue-impl-pr/issue-66
+- review_loop_status: pending
+- notes:
+  - PR 생성 후 `codex-pr-review-loop`로 handoff 예정
+  - review loop 종료 전까지 artifact `meta.md` 상태와 위키 후속 sync 가능성을 유지

--- a/.codex-workflows/github-next-issue-autopilot/issue-66-class-diagram-ui-hierarchy/handoff.md
+++ b/.codex-workflows/github-next-issue-autopilot/issue-66-class-diagram-ui-hierarchy/handoff.md
@@ -4,7 +4,10 @@
 - impl_route: direct-impl
 - artifact_dir: docs/artifacts/codex-issue-66-class-diagram-ui-hierarchy
 - impl_run_dir: .codex-workflows/github-issue-impl-pr/issue-66
+- pr_number: 70
+- pr_url: https://github.com/rlatndud9090/frdy/pull/70
 - review_loop_status: pending
 - notes:
-  - PR 생성 후 `codex-pr-review-loop`로 handoff 예정
+  - PR #70 생성 완료
+  - PR 본문에 `chatgpt-codex-connector[bot]`의 `eyes` 자동리뷰 접수를 확인했습니다.
   - review loop 종료 전까지 artifact `meta.md` 상태와 위키 후속 sync 가능성을 유지

--- a/.codex-workflows/github-next-issue-autopilot/issue-66-class-diagram-ui-hierarchy/run-summary.md
+++ b/.codex-workflows/github-next-issue-autopilot/issue-66-class-diagram-ui-hierarchy/run-summary.md
@@ -5,6 +5,8 @@
 - ralplan_used: no
 - ralph_used: no
 - branch_name: codex/issue-66-class-diagram-ui-hierarchy
+- pr_number: 70
+- pr_url: https://github.com/rlatndud9090/frdy/pull/70
 - current_result:
   - `docs/wiki/systems/class-architecture.md`에서 `MapOverlay`, `SettingsOverlay`의 잘못된 `UIElement` 상속 화살표를 제거했습니다.
   - branch artifact scaffold와 autopilot/impl handoff 문서를 생성해 후속 review loop와 wiki sync 가능성을 보존했습니다.
@@ -13,3 +15,5 @@
   - `./scripts/check_love.sh` -> success
   - `./scripts/check_artifact_guard.sh` -> skip (코드/데이터/테스트 변경 없음)
 - review_loop_exit_basis: pending
+- review_loop_state:
+  - initial PR auto-review `eyes` confirmed on PR body

--- a/.codex-workflows/github-next-issue-autopilot/issue-66-class-diagram-ui-hierarchy/run-summary.md
+++ b/.codex-workflows/github-next-issue-autopilot/issue-66-class-diagram-ui-hierarchy/run-summary.md
@@ -1,0 +1,15 @@
+# Run Summary
+
+- selected_issue: #66
+- chosen_route: direct-impl
+- ralplan_used: no
+- ralph_used: no
+- branch_name: codex/issue-66-class-diagram-ui-hierarchy
+- current_result:
+  - `docs/wiki/systems/class-architecture.md`에서 `MapOverlay`, `SettingsOverlay`의 잘못된 `UIElement` 상속 화살표를 제거했습니다.
+  - branch artifact scaffold와 autopilot/impl handoff 문서를 생성해 후속 review loop와 wiki sync 가능성을 보존했습니다.
+- validation:
+  - `./scripts/run_tests.sh` -> 122 passed
+  - `./scripts/check_love.sh` -> success
+  - `./scripts/check_artifact_guard.sh` -> skip (코드/데이터/테스트 변경 없음)
+- review_loop_exit_basis: pending

--- a/.codex-workflows/github-next-issue-autopilot/issue-66-class-diagram-ui-hierarchy/selection.md
+++ b/.codex-workflows/github-next-issue-autopilot/issue-66-class-diagram-ui-hierarchy/selection.md
@@ -1,0 +1,20 @@
+# Selection
+
+- selected_issue: #66 [Audit][Doc] CLASS_DIAGRAM UI 계층 상속관계 최신화
+- repository: rlatndud9090/frdy
+- rationale:
+  - 활성 PR이 없는 non-Fun 이슈 중 현재 코드/문서 불일치가 가장 명확했습니다.
+  - `#59`, `#58`, `#68`, `#60`은 현재 `main`과 테스트 기준으로 stale 가능성이 높아 즉시 착수 가치가 낮았습니다.
+  - `#66`은 실제 코드와 위키 다이어그램의 차이가 바로 재현되어 한 PR로 안전하게 수습 가능합니다.
+- deferred_candidates:
+  - #60: 현재 문서와 스크립트가 headless fallback을 이미 반영해 stale 가능성 높음
+  - #68: `main`에 headless fallback 수정 이력이 있어 stale 가능성 높음
+- handoff_seed:
+  - owner_repo: rlatndud9090/frdy
+  - issue_number: 66
+  - issue_url: https://github.com/rlatndud9090/frdy/issues/66
+  - why_now: 현재 코드 기준 문서 진실을 즉시 복구하는 최소 범위 작업
+  - scope_clarity: high
+  - likely_surface_area: single-file
+  - known_blockers_or_unknowns: issue 본문은 루트 `CLASS_DIAGRAM.md`를 언급하지만 실제 불일치는 위키 다이어그램에 남아 있는지 재확인 필요
+  - route_hint: direct-impl 후보

--- a/docs/artifacts/codex-issue-66-class-diagram-ui-hierarchy/meta.md
+++ b/docs/artifacts/codex-issue-66-class-diagram-ui-hierarchy/meta.md
@@ -1,0 +1,36 @@
+---
+id: codex-issue-66-class-diagram-ui-hierarchy
+branch: codex/issue-66-class-diagram-ui-hierarchy
+status: in_progress
+wiki_sync_status: pending
+created_at: 2026-04-15
+updated_at: 2026-04-15
+related_issue: "#66"
+related_pr:
+merge_commit:
+wiki_targets:
+  - docs/wiki/systems/class-architecture.md
+---
+
+# Work Unit Meta
+
+## Goal
+
+- UI 계층 다이어그램을 현재 코드 기준으로 정정합니다.
+- `MapOverlay`, `SettingsOverlay`가 `UIElement` 상속으로 오해되지 않도록 위키를 맞춥니다.
+
+## Scope
+
+- 포함 범위: `docs/wiki/systems/class-architecture.md`의 UI 다이어그램 정정, 이슈/PR handoff 메타 유지
+- 제외 범위: 런타임 UI 클래스 리팩터링, 다른 stale 이슈 정리, main 머지 후 wiki sync 확정 처리
+
+## Acceptance
+
+- `MapOverlay`, `SettingsOverlay`가 위키 다이어그램에서 `UIElement` 하위 클래스로 표기되지 않습니다.
+- artifact `status`, `wiki_sync_status`, 이슈/PR 연계 정보가 작업 중에도 유지됩니다.
+- PR 생성 전 필수 검증과 artifact guard를 통과합니다.
+
+## Notes
+
+- 이슈 본문은 루트 `CLASS_DIAGRAM.md`를 언급하지만, 현재 워크트리의 실제 불일치는 위키 문서에 남아 있었습니다.
+- main 머지 후 위키 sync가 끝나면 `wiki_sync_status: synced`로 후속 갱신합니다.

--- a/docs/artifacts/codex-issue-66-class-diagram-ui-hierarchy/meta.md
+++ b/docs/artifacts/codex-issue-66-class-diagram-ui-hierarchy/meta.md
@@ -6,7 +6,7 @@ wiki_sync_status: pending
 created_at: 2026-04-15
 updated_at: 2026-04-15
 related_issue: "#66"
-related_pr:
+related_pr: "#70"
 merge_commit:
 wiki_targets:
   - docs/wiki/systems/class-architecture.md

--- a/docs/artifacts/codex-issue-66-class-diagram-ui-hierarchy/prd.md
+++ b/docs/artifacts/codex-issue-66-class-diagram-ui-hierarchy/prd.md
@@ -1,0 +1,12 @@
+# PRD
+
+- work-unit: codex-issue-66-class-diagram-ui-hierarchy
+- branch: codex/issue-66-class-diagram-ui-hierarchy
+
+## Problem
+
+## Goal
+
+## Constraints
+
+## Acceptance

--- a/docs/artifacts/codex-issue-66-class-diagram-ui-hierarchy/timeline.md
+++ b/docs/artifacts/codex-issue-66-class-diagram-ui-hierarchy/timeline.md
@@ -1,0 +1,7 @@
+# Timeline
+
+- YYYY-MM-DD HH:MM | 작업 시작
+- YYYY-MM-DD HH:MM | 주요 결정 기록
+- YYYY-MM-DD HH:MM | PR 생성
+- YYYY-MM-DD HH:MM | 리뷰 반영
+- YYYY-MM-DD HH:MM | main 머지

--- a/docs/wiki/systems/class-architecture.md
+++ b/docs/wiki/systems/class-architecture.md
@@ -204,8 +204,6 @@ classDiagram
   SpellBookOverlay --|> UIElement
   EdgeSelector --|> UIElement
   Minimap --|> UIElement
-  MapOverlay --|> UIElement
-  SettingsOverlay --|> UIElement
 
   GameScene --> CombatHandler
   GameScene --> EventHandler


### PR DESCRIPTION
## 요약
- 위키 클래스 다이어그램에서 `MapOverlay`, `SettingsOverlay`의 잘못된 `UIElement` 상속 화살표를 제거했습니다.
- branch artifact scaffold와 autopilot/impl handoff 문서를 남겨 review loop 및 후속 wiki sync 가능성을 보존했습니다.

## 검증
- `./scripts/run_tests.sh` ✅ (122 passed)
- `./scripts/check_love.sh` ✅
- `./scripts/check_artifact_guard.sh` ✅ (코드/데이터/테스트 변경 없음으로 skip)

## 관련 이슈
- closes #66

## Route
- judge route: `direct-impl`
- judge artifact: `.codex-workflows/github-issue-impl-pr/issue-66/judge-route.json`
- ralplan artifacts: `none`
- ralph artifacts: `none`

## 문서 동기화
- authoritative class diagram은 `docs/wiki/systems/class-architecture.md`이므로 해당 위키만 갱신했습니다.
- 루트 `CLASS_DIAGRAM.md`는 포인터 문서라 별도 수정이 필요하지 않았습니다.
