### PR TITLE
docs: late pre-artifact 구현 이력 복원

### DIFF
--- a/docs/artifacts/codex-issue-71-late-pre-artifact-history/meta.md
+++ b/docs/artifacts/codex-issue-71-late-pre-artifact-history/meta.md
@@ -1,0 +1,37 @@
+---
+id: codex-issue-71-late-pre-artifact-history
+branch: codex/issue-71-late-pre-artifact-history
+status: ready-for-pr
+wiki_sync_status: synced
+created_at: 2026-04-16
+updated_at: 2026-04-16
+related_issue: "#71"
+related_pr:
+merge_commit:
+wiki_targets:
+  - docs/wiki/project/implementation-history.md
+  - docs/wiki/log.md
+---
+
+# Work Unit Meta
+
+## Goal
+
+- 71번 이슈에서 지적한 late pre-artifact 구간의 구현 이력 누락을 메웁니다.
+- 2026-03-20부터 2026-04-14까지의 핵심 변경을 새 backfill artifact와 현재형 wiki에 반영합니다.
+
+## Scope
+
+- 포함 범위: late pre-artifact backfill artifact 생성, `implementation-history.md` 보강, `wiki/log.md` 기록 추가
+- 제외 범위: post-artifact 개별 work unit 재정리, 런타임 코드 수정, 다른 stale wiki 이슈 처리
+
+## Acceptance
+
+- `docs/wiki/project/implementation-history.md`가 2026-03-20 이후 공백 구간을 현재 코드 구조 관점에서 설명합니다.
+- 새 backfill artifact가 late pre-artifact 구간의 근거와 한계를 남깁니다.
+- 작업 단위 메타와 wiki sync 상태가 실제 반영 결과와 맞게 유지됩니다.
+
+## Notes
+
+- 기존 `history-bootstrap-2026-04`는 2026-03-19까지의 초기 복원본으로 유지하고, 이후 구간은 별도 backfill artifact로 분리합니다.
+- late pre-artifact 해석은 `현재 코드 > 해당 시기 커밋 메시지/변경 요약 > 이슈 본문` 우선순위로 정리합니다.

--- a/docs/artifacts/codex-issue-71-late-pre-artifact-history/prd.md
+++ b/docs/artifacts/codex-issue-71-late-pre-artifact-history/prd.md
@@ -1,0 +1,25 @@
+# PRD
+
+- work-unit: codex-issue-71-late-pre-artifact-history
+- branch: codex/issue-71-late-pre-artifact-history
+
+## Problem
+
+- `docs/wiki/project/implementation-history.md`가 2026-03-19 이후의 핵심 구조 변화를 건너뛰고 있어 현재 런 종료, 저장, 검증, wiki 운영 구조가 어떤 순서로 형성됐는지 설명하지 못합니다.
+
+## Goal
+
+- late pre-artifact 구간을 별도 backfill artifact로 복원합니다.
+- 현재형 wiki가 해당 구간의 구조 변화를 요약하도록 갱신합니다.
+
+## Constraints
+
+- 기존 `history-bootstrap-2026-04`의 범위와 의미는 보존합니다.
+- 위키는 append-only가 아니라 현재형 재합성 문서로 유지합니다.
+- post-artifact 작업 단위와 혼동되지 않게 2026-04-14 이전까지만 다룹니다.
+
+## Acceptance
+
+- 새 backfill artifact에 기간, 핵심 변화, 한계가 기록됩니다.
+- `docs/wiki/project/implementation-history.md`가 런 종료/이어하기, headless 검증, 종료 경로 복구, wiki 운영 도입을 별도 구간으로 설명합니다.
+- `docs/wiki/log.md`에 이번 backfill 반영이 남습니다.

--- a/docs/artifacts/codex-issue-71-late-pre-artifact-history/timeline.md
+++ b/docs/artifacts/codex-issue-71-late-pre-artifact-history/timeline.md
@@ -1,0 +1,5 @@
+# Timeline
+
+- 2026-04-16 13:16 | 이슈 #71 기준으로 `implementation-history.md`와 `history-bootstrap-2026-04` 사이의 공백 구간을 조사 시작
+- 2026-04-16 13:24 | 2026-03-20..2026-04-14 커밋을 런 종료/이어하기, headless 검증, 종료 경로 복구, wiki 운영 도입 축으로 분류하기로 결정
+- 2026-04-16 13:24 | late pre-artifact 전용 backfill artifact를 새로 만들고 기존 초기 bootstrap artifact 범위는 유지하기로 결정

--- a/docs/artifacts/history-bootstrap-late-pre-artifact-2026-04/meta.md
+++ b/docs/artifacts/history-bootstrap-late-pre-artifact-2026-04/meta.md
@@ -1,0 +1,38 @@
+---
+id: history-bootstrap-late-pre-artifact-2026-04
+branch: historical-backfill
+status: archived
+wiki_sync_status: synced
+created_at: 2026-04-16
+updated_at: 2026-04-16
+related_issue: "#71"
+related_pr:
+merge_commit:
+wiki_targets:
+  - docs/wiki/project/implementation-history.md
+  - docs/wiki/log.md
+---
+
+# Work Unit Meta
+
+## Goal
+
+- artifact 체계 도입 직전의 late pre-artifact 구현 이력을 사후 복원합니다.
+- 현재 코드가 가진 런 종료, 저장, 검증, wiki 운영 구조의 형성 구간을 현재형 wiki가 설명할 수 있게 합니다.
+
+## Scope
+
+- 포함 범위: 2026-03-20부터 2026-04-14까지의 핵심 구현 이력 요약, late pre-artifact backfill, 관련 wiki 보강
+- 제외 범위: 2026-04-14 이후 개별 work unit artifact 재정리, PR 리뷰 원문 복원, post-artifact 상세 연대기 작성
+
+## Acceptance
+
+- late pre-artifact 구간의 핵심 변화가 backfill artifact와 현재형 wiki에 반영되어야 합니다.
+- `implementation-history.md`가 현재 런 종료/검증/지식 운영 구조를 만든 중간 단계를 건너뛰지 않아야 합니다.
+- `wiki/log.md`가 이 backfill 반영 사실을 기록해야 합니다.
+
+## Notes
+
+- 이 artifact는 실시간으로 쌓인 원본이 아니라 사후 복원 백필입니다.
+- 근거 강도는 `현재 코드 > 커밋 메시지/변경 요약 > 이슈 본문` 순으로 해석합니다.
+- 기존 `history-bootstrap-2026-04`는 2026-03-19까지의 초기 복원본으로 유지하고, 본 artifact는 그 이후 구간만 담당합니다.

--- a/docs/artifacts/history-bootstrap-late-pre-artifact-2026-04/summary.md
+++ b/docs/artifacts/history-bootstrap-late-pre-artifact-2026-04/summary.md
@@ -1,0 +1,47 @@
+# Late Pre-Artifact History Bootstrap Summary
+
+이 문서는 artifact 체계 도입 직전인 `2026-03-20..2026-04-14` 구간의 `frdy` 구현 이력을 사후 복원한 요약입니다.
+
+## 사용한 근거
+
+- 현재 코드 구조와 현재형 wiki
+- 해당 기간 `main` 커밋 로그와 커밋 본문
+- 이슈 #71이 수집한 누락 구간 후보와 파일 위치
+
+## 복원된 큰 흐름
+
+### 1. 메인 메뉴, 이어하기, 런 종료 구조 정착
+
+- 2026-03-24에 `MainMenuScene`, `RunEndScene`, 확인 모달, active save JSON/checksum/backup 구조가 함께 들어왔습니다.
+- 저장 책임은 `GameScene` 단독 처리에서 `RunSaveCoordinator`와 participant registry 쪽으로 분리되었습니다.
+- 이 구간이 현재 메인 메뉴의 `이어하기`, 런 종료 화면, 체크포인트 저장/복원 흐름의 기준선을 만들었습니다.
+
+### 2. 헤드리스 Love 검증 fallback 도입
+
+- 같은 날 `scripts/check_love.sh`에 no-display 상황을 감지해 headless smoke check로 전환하는 fallback이 추가되었습니다.
+- 이 변경으로 디스플레이가 없는 자동화 환경에서도 Love 실행 검증을 필수 절차로 유지할 수 있게 되었습니다.
+
+### 3. 층 전환과 패배 종료 흐름 복구
+
+- 2026-03-26과 2026-04-01 사이에 다음 층 전환 체크포인트, 런 종료 정리, `GAME_OVER` 전환 누락이 연속 보수되었습니다.
+- 이 시기 수정으로 현재 `GameScene`은 층 전환 대기, 패배 종료, 재시작 입력 경로를 명시 상태 전환으로 처리합니다.
+
+### 4. 이벤트 치사 피해와 의심 최대치 종료 연결
+
+- 2026-04-09에 이벤트 치사 피해와 `suspicion_max` 도달을 공통 런 종료 정리 경로에 연결하는 수정이 들어왔습니다.
+- 이 흐름은 전투 밖에서 발생한 종료 사유도 active save 정리와 종료 씬 표시를 일관되게 거치도록 만들었습니다.
+
+### 5. LLM Wiki + artifact 운영 기반 도입
+
+- 2026-04-14에 `docs/wiki/`와 `docs/artifacts/` 2계층 구조, scaffold/guard 스크립트, bootstrap history 복원 체계가 도입되었습니다.
+- 이후부터 구현 근거는 work unit artifact에 쌓고, 위키는 그 근거를 바탕으로 현재형으로 재합성하는 운영 기준이 정착했습니다.
+
+## 한계
+
+- 이 artifact 역시 원본 회의록이나 PR 리뷰 스레드 전체를 복원하지는 않습니다.
+- 커밋 메시지와 현재 코드로 검증 가능한 구조 변화만 골라 요약했습니다.
+
+## 후속 운영 원칙
+
+- pre-artifact 구간을 참조할 때는 `history-bootstrap-2026-04`와 본 artifact를 함께 읽습니다.
+- 2026-04-14 이후의 변화는 개별 work unit artifact를 진실의 원천으로 사용합니다.

--- a/docs/artifacts/history-bootstrap-late-pre-artifact-2026-04/timeline.md
+++ b/docs/artifacts/history-bootstrap-late-pre-artifact-2026-04/timeline.md
@@ -1,0 +1,5 @@
+# Timeline
+
+- 2026-04-16 13:16 | 이슈 #71 기준으로 late pre-artifact 누락 구간 조사 시작
+- 2026-04-16 13:24 | 2026-03-20..2026-04-14 커밋을 저장/종료, 검증, wiki 운영 축으로 정리
+- 2026-04-16 13:24 | `implementation-history.md`, `wiki/log.md`를 함께 갱신하고 `wiki_sync_status: synced`로 정리

--- a/docs/wiki/log.md
+++ b/docs/wiki/log.md
@@ -3,3 +3,4 @@
 - 2026-04-14 | wiki-init | 루트 설계 문서를 `docs/wiki/` 체계로 이관하고 LLM Wiki 스키마를 도입했다.
 - 2026-04-14 | history-bootstrap | 현재 코드, 루트 문서, git log를 근거로 pre-artifact 구현 히스토리를 사후 복원했다.
 - 2026-04-14 | artifact-bootstrap | `wiki-init-2026-04` work unit artifact를 생성해 초기 도입 작업 자체를 근거층에 남겼다.
+- 2026-04-16 | history-bootstrap-late-pre-artifact | 2026-03-20부터 2026-04-14까지의 late pre-artifact 구현 이력을 별도 backfill artifact와 `implementation-history.md`에 반영했다.

--- a/docs/wiki/project/implementation-history.md
+++ b/docs/wiki/project/implementation-history.md
@@ -39,12 +39,32 @@
 - 2026-03-02에 정산 기반 보상 시스템, `RewardManager`, `DemonAwakening`, `LegendaryInventory`, 자동화 테스트가 추가됐습니다.
 - 2026-03-04에 `RunContext` 기반 결정론 RNG가 들어오며 런 전체를 시드 재현 가능한 구조로 정리했습니다.
 
-## 8. 메인 메뉴, 이어하기, 런 종료 루프 보강
+## 8. 메인 메뉴, 이어하기, 런 종료 구조 정착
 
-- 이후 `MainMenuScene`, `RunEndScene`, active save/coordinator 계층이 더해지며 런 시작과 종료 경험이 보강됐습니다.
-- 현재는 메인 메뉴에서 `이어하기`가 가능하고, 체크포인트 기반 저장/복원이 `GameScene` 내부 흐름과 연결되어 있습니다.
+- 2026-03-24에 `MainMenuScene`, `RunEndScene`, 확인 모달, active save JSON/checksum/backup 구조가 함께 들어왔습니다.
+- 저장 책임은 `GameScene`에서 `RunSaveCoordinator`와 participant registry 계층으로 분리되었고, 현재의 `이어하기`와 종료 화면 경험이 이 시점에 자리잡았습니다.
+
+## 9. 헤드리스 Love 검증 fallback 도입
+
+- 같은 날 `scripts/check_love.sh`에 no-display 환경 감지와 headless smoke check fallback이 추가됐습니다.
+- 이 변경으로 현재의 자동 검증 절차는 GUI가 없는 환경에서도 Love 실행 검증을 유지할 수 있게 되었습니다.
+
+## 10. 층 전환과 패배 종료 흐름 복구
+
+- 2026-03-26과 2026-04-01에 런 종료 정리, 다음 층 체크포인트, `GAME_OVER` 전환 누락이 연속 보수되었습니다.
+- 현재 `GameScene`이 층 전환 대기, 패배 종료, 재시작 입력 흐름을 명시 상태 전환으로 다루는 이유가 이 시기 수정에서 고정됐습니다.
+
+## 11. 이벤트 치사 피해와 의심 최대치 종료 연결
+
+- 2026-04-09에 이벤트 치사 피해와 `suspicion_max` 도달이 공통 런 종료 정리 경로에 연결되었습니다.
+- 이 흐름으로 전투 밖 종료 사유도 active save 정리와 종료 사유 표시를 일관되게 거치도록 맞춰졌습니다.
+
+## 12. LLM Wiki와 artifact 운영 기반 도입
+
+- 2026-04-14에 `docs/wiki/`와 `docs/artifacts/` 2계층, scaffold/guard 스크립트, pre-artifact bootstrap 복원 체계가 도입되었습니다.
+- 현재는 work unit artifact를 근거층으로 쌓고, 위키를 그 근거로 재합성하는 운영 규칙이 이 시점부터 프로젝트 기본 규약이 되었습니다.
 
 ## 해석 규칙
 
 - 이 문서는 “현재 구조가 왜 이렇게 생겼는가”를 설명하는 현재형 요약입니다.
-- 세부 근거가 더 필요하면 `docs/artifacts/history-bootstrap-2026-04/`를 먼저 보고, 이후 작업은 개별 work unit artifact를 참조합니다.
+- 세부 근거가 더 필요하면 `docs/artifacts/history-bootstrap-2026-04/`와 `docs/artifacts/history-bootstrap-late-pre-artifact-2026-04/`를 먼저 보고, 이후 작업은 개별 work unit artifact를 참조합니다.


### PR DESCRIPTION
## 요약
- 2026-03-20..2026-04-14 구간을 별도 late pre-artifact backfill artifact로 추가했습니다.
- `docs/wiki/project/implementation-history.md`에 런 종료/이어하기, headless Love 검증, 종료 경로 복구, wiki 운영 도입 흐름을 현재형으로 보강했습니다.
- `docs/wiki/log.md`에 이번 backfill 반영 기록을 남겼습니다.

## 검증
- `./scripts/check_artifact_guard.sh` (`코드/데이터 변경이 없어 artifact guard를 건너뜁니다.`)
- `./scripts/run_tests.sh`
- `./scripts/check_love.sh`

## 관련 이슈
- Closes #71

## 구현 경로
- route: `direct-impl`

## 문서 동기화 메모
- 이 PR은 위키/아티팩트 누락 보강 자체가 목적이라 `docs/wiki/project/implementation-history.md`, `docs/wiki/log.md`를 함께 갱신했습니다.