### PR TITLE
chore: artifact completeness guard와 main wiki sync 도입

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Validate artifact scaffold exists for code changes
+      - name: Validate artifact completeness for branch work
         run: ./scripts/check_artifact_guard.sh "origin/${{ github.base_ref }}"
 
   test-required:
@@ -44,3 +44,15 @@ jobs:
 
       - name: Run unit/integration tests
         run: ./scripts/run_tests.sh
+
+  main-artifact-audit:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Audit merged changes include complete artifacts
+        run: ./scripts/check_main_artifact_audit.sh "${{ github.event.before }}" "${{ github.sha }}"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -183,10 +183,12 @@ function ClassName:method(name, optional_param)
 - `docs/wiki/`는 현재형 지식층이며, 에이전트는 기본적으로 이 계층을 먼저 읽는다.
 - `docs/artifacts/`는 작업 단위별 진실의 원천이다. 회의록, AI 대화, PRD, ADR, 실험 로그, 리뷰 메모는 모두 이 계층에 쌓는다.
 - `docs/artifacts/`는 기본 RAG 대상이 아니다. 위키 갱신, 근거 확인, 모순 해소가 필요할 때만 내려간다.
-- 브랜치에서 코드/데이터/테스트 작업을 시작할 때는 반드시 `./scripts/ensure_artifact_scaffold.sh`를 먼저 실행해 해당 작업 단위의 artifact scaffold를 만든다.
+- 브랜치/워크트리에서 작업을 시작할 때는 `./scripts/start_work_unit.sh`로 artifact 초안을 먼저 채운다. `ensure_artifact_scaffold.sh` 단독 실행은 예외적인 수동 복구 용도로만 사용한다.
+- 첫 코드/문서/스크립트 편집 전과 커밋 전에는 `./scripts/check_artifact_progress.sh`가 통과하는 상태를 유지한다.
 - PR 전에는 `./scripts/check_artifact_guard.sh`를 통과해야 한다.
+- 템플릿 문구만 남은 `prd.md`, `timeline.md`, `meta.md`는 artifact가 없는 것과 동일하게 간주한다.
 - 위키 갱신은 기본적으로 머지 후 수행한다. PR 생성 전 위키 완료를 강제하지 않는다.
-- 다만 artifact의 `meta.md`에는 최소한 `status`, `wiki_sync_status`를 유지한다.
+- 다만 artifact의 `meta.md`에는 최소한 `status`, `wiki_sync_status`, `updated_at`를 유지한다.
 - 위키 관련 요청이면 먼저 아래 문서를 읽는다.
   - `docs/wiki/SCHEMA.md`
   - `docs/wiki/RESOLVER.md`

--- a/README.md
+++ b/README.md
@@ -37,6 +37,16 @@ love .
 - `run_tests.sh`: 단위/통합 테스트를 실행하고, `FRDY_RUN_SEED`가 unset/empty면 고정 기본 seed를 주입합니다. non-empty 값은 그대로 전달되며 결정론 보장은 런타임이 숫자로 해석하는 경우에 한합니다.
 - `check_love.sh`: 기본적으로 `FRDY_CI_CHECK=1` 기반 Love2D 무팝업 실행 검증을 수행하고, 디스플레이가 없는 자동화 환경에서는 Lua headless bootstrap smoke check로 자동 전환합니다. `FRDY_RUN_SEED` semantics는 기본 Love 실행과 headless fallback 경로에서 동일합니다.
 
+## 작업 시작 규칙
+
+```bash
+./scripts/start_work_unit.sh --summary "<작업 요약>"
+./scripts/check_artifact_progress.sh
+```
+
+- 작업 브랜치에서는 `start_work_unit.sh`로 artifact 초안을 먼저 채운 뒤 구현을 시작합니다.
+- PR 전에는 `./scripts/check_artifact_guard.sh origin/main`이, main 반영 후에는 `./scripts/check_main_artifact_audit.sh`가 껍데기 artifact를 차단합니다.
+
 ## 프로젝트 구조
 
 ```text

--- a/docs/artifacts/README.md
+++ b/docs/artifacts/README.md
@@ -31,13 +31,14 @@ docs/artifacts/
 
 `meta.md` frontmatter의 `wiki_sync_status`를 기준으로 후속 작업을 추적합니다.
 
-- `not-started`: 작업 중이며 아직 위키 갱신 판단 전
+- `not-started`: scaffold만 만든 초기 상태이며, 진행 중 작업에는 허용하지 않음
 - `pending`: 위키 반영이 필요함
 - `synced`: 관련 위키 반영이 완료됨
 
 `status`는 작업 자체의 라이프사이클을 나타냅니다.
 
-- `collecting`: 아티팩트 수집 중
+- `collecting`: scaffold만 생성된 상태. 실제 작업을 시작하기 전까지만 허용
+- `in_progress`: 작업 요약, 범위, 수용 기준, 타임라인 초안이 채워진 진행 상태
 - `ready-for-pr`: PR 생성 가능
 - `in-review`: PR 리뷰 진행 중
 - `merged`: main 머지 완료
@@ -45,7 +46,9 @@ docs/artifacts/
 
 ## 운영 메모
 
-- 브랜치 작업을 시작할 때 `./scripts/ensure_artifact_scaffold.sh`로 스캐폴드를 만듭니다.
-- PR 전에는 `./scripts/check_artifact_guard.sh`가 최소 요건을 확인합니다.
+- 브랜치 작업을 시작할 때는 `./scripts/start_work_unit.sh`로 artifact 초안을 채웁니다.
+- `./scripts/check_artifact_progress.sh`는 현재 브랜치 artifact가 껍데기 상태인지 확인합니다.
+- PR 전에는 `./scripts/check_artifact_guard.sh`가 파일 존재뿐 아니라 본문 충실도까지 확인합니다.
+- `main` push 후에는 `./scripts/check_main_artifact_audit.sh`가 머지된 변경에 artifact가 함께 반영됐는지 감사합니다.
 - main 머지 후 위키 갱신 자동화는 `./scripts/check_wiki_sync_guard.sh` 출력을 기반으로 후속 실행할 수 있게 설계합니다.
 - 이 자동화는 `status: merged`를 별도 전제조건으로 요구하지 않습니다. `main`에 존재하는 `wiki_sync_status: pending` artifact면 sync 후보입니다.

--- a/docs/artifacts/codex-artifact-hardening-main-wiki-sync/meta.md
+++ b/docs/artifacts/codex-artifact-hardening-main-wiki-sync/meta.md
@@ -1,12 +1,12 @@
 ---
 id: codex-artifact-hardening-main-wiki-sync
 branch: codex/artifact-hardening-main-wiki-sync
-status: ready-for-pr
+status: in-review
 wiki_sync_status: pending
 created_at: 2026-04-16
-updated_at: 2026-04-16
+updated_at: 2026-04-17
 related_issue: 
-related_pr:
+related_pr: https://github.com/rlatndud9090/frdy/pull/73
 merge_commit:
 wiki_targets:
   - docs/wiki/project/wiki-sync-automation.md

--- a/docs/artifacts/codex-artifact-hardening-main-wiki-sync/meta.md
+++ b/docs/artifacts/codex-artifact-hardening-main-wiki-sync/meta.md
@@ -1,0 +1,37 @@
+---
+id: codex-artifact-hardening-main-wiki-sync
+branch: codex/artifact-hardening-main-wiki-sync
+status: in_progress
+wiki_sync_status: pending
+created_at: 2026-04-16
+updated_at: 2026-04-16
+related_issue: 
+related_pr:
+merge_commit:
+wiki_targets:
+  - docs/wiki/project/wiki-sync-automation.md
+  - docs/wiki/RESOLVER.md
+  - docs/wiki/project/overview.md
+---
+
+# Work Unit Meta
+
+## Goal
+
+- artifact completeness guard와 main 기준 wiki sync 스킬을 도입합니다.
+- 이 브랜치의 변경과 검증 결과를 artifact에 지속적으로 누적합니다.
+
+## Scope
+
+- 포함 범위: artifact 시작 절차, completeness guard, main push audit, main 기준 wiki sync 스킬, 관련 운영 문서 정리
+- 제외 범위: 게임 런타임 로직 변경, 기존 feature 구현 범위 확장
+
+## Acceptance
+
+- 새 시작 스크립트와 completeness guard가 실제로 이 브랜치 artifact를 채우고 통과시킵니다.
+- PR 전 `./scripts/check_artifact_progress.sh`와 `./scripts/check_artifact_guard.sh`를 통과합니다.
+
+## Notes
+
+- 이 브랜치는 규칙 강화와 스킬 추가를 한 번에 정리하는 인프라 작업입니다.
+- `frdy-main-wiki-sync` 스킬은 최신 `main`만 기준으로 wiki sync를 수행하고, 본 브랜치의 guard는 그 전제인 artifact completeness를 보장합니다.

--- a/docs/artifacts/codex-artifact-hardening-main-wiki-sync/meta.md
+++ b/docs/artifacts/codex-artifact-hardening-main-wiki-sync/meta.md
@@ -1,7 +1,7 @@
 ---
 id: codex-artifact-hardening-main-wiki-sync
 branch: codex/artifact-hardening-main-wiki-sync
-status: in_progress
+status: ready-for-pr
 wiki_sync_status: pending
 created_at: 2026-04-16
 updated_at: 2026-04-16

--- a/docs/artifacts/codex-artifact-hardening-main-wiki-sync/prd.md
+++ b/docs/artifacts/codex-artifact-hardening-main-wiki-sync/prd.md
@@ -1,0 +1,20 @@
+# PRD
+
+- work-unit: codex-artifact-hardening-main-wiki-sync
+- branch: codex/artifact-hardening-main-wiki-sync
+
+## Problem
+
+- artifact completeness guard와 main 기준 wiki sync 스킬을 도입합니다.
+
+## Goal
+
+- artifact completeness guard와 main 기준 wiki sync 스킬을 도입합니다.
+
+## Constraints
+
+- 기존 artifact/wiki 운영 흐름을 유지하면서도 템플릿-only artifact가 PR과 main을 통과하지 못하게 막습니다.
+
+## Acceptance
+
+- 새 시작 스크립트와 completeness guard가 실제로 이 브랜치 artifact를 채우고 통과시킵니다.

--- a/docs/artifacts/codex-artifact-hardening-main-wiki-sync/timeline.md
+++ b/docs/artifacts/codex-artifact-hardening-main-wiki-sync/timeline.md
@@ -10,3 +10,4 @@
 - 2026-04-17 14:27 | PR #73 오픈 후 Codex 리뷰에서 placeholder 오탐 가능성을 확인하고 `validate_no_placeholders`를 줄 단위 검사로 보강
 - 2026-04-17 14:37 | 재리뷰에서 날짜 포맷 substring 오탐을 확인하고 frontmatter 값 및 타임라인 템플릿 줄만 검사하도록 placeholder 검사를 축소
 - 2026-04-17 14:43 | 재리뷰에서 Scope 라벨만 남겨도 통과하는 문제를 확인하고 `포함 범위:`/`제외 범위:` 뒤 실제 내용 존재 여부를 PR completeness 검증에 추가
+- 2026-04-17 14:52 | 재리뷰에서 과거 artifact 수정까지 PR 상태 게이트로 막는 문제를 확인하고 `check_artifact_guard.sh`가 비현재 artifact에는 `main-audit` 검증을 사용하도록 조정

--- a/docs/artifacts/codex-artifact-hardening-main-wiki-sync/timeline.md
+++ b/docs/artifacts/codex-artifact-hardening-main-wiki-sync/timeline.md
@@ -7,3 +7,4 @@
 - 2026-04-16 14:17 | `frdy-main-wiki-sync` 스킬 설치 및 운영 문서/README/overview 동기화
 - 2026-04-16 14:21 | macOS 기본 Bash 3.x에서 `mapfile` 비호환 이슈를 제거하고 guard/audit 통과 확인
 - 2026-04-16 14:22 | `run_tests.sh`, `check_love.sh`, artifact progress/guard/main audit 검증 완료
+- 2026-04-17 14:27 | PR #73 오픈 후 Codex 리뷰에서 placeholder 오탐 가능성을 확인하고 `validate_no_placeholders`를 줄 단위 검사로 보강

--- a/docs/artifacts/codex-artifact-hardening-main-wiki-sync/timeline.md
+++ b/docs/artifacts/codex-artifact-hardening-main-wiki-sync/timeline.md
@@ -9,3 +9,4 @@
 - 2026-04-16 14:22 | `run_tests.sh`, `check_love.sh`, artifact progress/guard/main audit 검증 완료
 - 2026-04-17 14:27 | PR #73 오픈 후 Codex 리뷰에서 placeholder 오탐 가능성을 확인하고 `validate_no_placeholders`를 줄 단위 검사로 보강
 - 2026-04-17 14:37 | 재리뷰에서 날짜 포맷 substring 오탐을 확인하고 frontmatter 값 및 타임라인 템플릿 줄만 검사하도록 placeholder 검사를 축소
+- 2026-04-17 14:43 | 재리뷰에서 Scope 라벨만 남겨도 통과하는 문제를 확인하고 `포함 범위:`/`제외 범위:` 뒤 실제 내용 존재 여부를 PR completeness 검증에 추가

--- a/docs/artifacts/codex-artifact-hardening-main-wiki-sync/timeline.md
+++ b/docs/artifacts/codex-artifact-hardening-main-wiki-sync/timeline.md
@@ -1,0 +1,7 @@
+# Timeline
+
+- 2026-04-16 14:06 | 작업 시작 및 artifact 초기화
+- 2026-04-16 14:06 | 작업 요약 확정: artifact completeness guard와 main 기준 wiki sync 스킬을 도입합니다.
+- 2026-04-16 14:11 | `start_work_unit.sh`, `check_artifact_progress.sh`, `check_artifact_completeness.py`, `check_main_artifact_audit.sh` 설계/구현
+- 2026-04-16 14:15 | CI artifact guard를 completeness 검증으로 교체하고 main push audit job을 추가
+- 2026-04-16 14:17 | `frdy-main-wiki-sync` 스킬 설치 및 운영 문서/README/overview 동기화

--- a/docs/artifacts/codex-artifact-hardening-main-wiki-sync/timeline.md
+++ b/docs/artifacts/codex-artifact-hardening-main-wiki-sync/timeline.md
@@ -8,3 +8,4 @@
 - 2026-04-16 14:21 | macOS 기본 Bash 3.x에서 `mapfile` 비호환 이슈를 제거하고 guard/audit 통과 확인
 - 2026-04-16 14:22 | `run_tests.sh`, `check_love.sh`, artifact progress/guard/main audit 검증 완료
 - 2026-04-17 14:27 | PR #73 오픈 후 Codex 리뷰에서 placeholder 오탐 가능성을 확인하고 `validate_no_placeholders`를 줄 단위 검사로 보강
+- 2026-04-17 14:37 | 재리뷰에서 날짜 포맷 substring 오탐을 확인하고 frontmatter 값 및 타임라인 템플릿 줄만 검사하도록 placeholder 검사를 축소

--- a/docs/artifacts/codex-artifact-hardening-main-wiki-sync/timeline.md
+++ b/docs/artifacts/codex-artifact-hardening-main-wiki-sync/timeline.md
@@ -5,3 +5,5 @@
 - 2026-04-16 14:11 | `start_work_unit.sh`, `check_artifact_progress.sh`, `check_artifact_completeness.py`, `check_main_artifact_audit.sh` 설계/구현
 - 2026-04-16 14:15 | CI artifact guard를 completeness 검증으로 교체하고 main push audit job을 추가
 - 2026-04-16 14:17 | `frdy-main-wiki-sync` 스킬 설치 및 운영 문서/README/overview 동기화
+- 2026-04-16 14:21 | macOS 기본 Bash 3.x에서 `mapfile` 비호환 이슈를 제거하고 guard/audit 통과 확인
+- 2026-04-16 14:22 | `run_tests.sh`, `check_love.sh`, artifact progress/guard/main audit 검증 완료

--- a/docs/artifacts/codex-artifact-hardening-main-wiki-sync/timeline.md
+++ b/docs/artifacts/codex-artifact-hardening-main-wiki-sync/timeline.md
@@ -11,3 +11,4 @@
 - 2026-04-17 14:37 | 재리뷰에서 날짜 포맷 substring 오탐을 확인하고 frontmatter 값 및 타임라인 템플릿 줄만 검사하도록 placeholder 검사를 축소
 - 2026-04-17 14:43 | 재리뷰에서 Scope 라벨만 남겨도 통과하는 문제를 확인하고 `포함 범위:`/`제외 범위:` 뒤 실제 내용 존재 여부를 PR completeness 검증에 추가
 - 2026-04-17 14:52 | 재리뷰에서 과거 artifact 수정까지 PR 상태 게이트로 막는 문제를 확인하고 `check_artifact_guard.sh`가 비현재 artifact에는 `main-audit` 검증을 사용하도록 조정
+- 2026-04-17 14:59 | 재리뷰에서 PR head 브랜치명이 `main`인 포크 PR 우회 가능성을 확인하고 `GITHUB_HEAD_REF`가 있는 PR 컨텍스트에서는 artifact guard를 계속 수행하도록 수정

--- a/docs/wiki/RESOLVER.md
+++ b/docs/wiki/RESOLVER.md
@@ -67,5 +67,6 @@
 ## 5. 작업 종료 규칙
 
 - 작업 단위 아티팩트가 생성되면 `meta.md`를 유지합니다.
+- scaffold만 만든 `collecting` 상태로는 작업을 지속하지 않습니다. 최소한 범위/수용 기준/타임라인 초안을 채우고 `in_progress` 이상으로 올립니다.
 - PR 생성 전 `wiki_sync_status`를 최소 `pending` 또는 `synced`로 명시합니다.
 - main 머지 후에는 `main`에 반영된 `wiki_sync_status: pending` artifact를 대상으로 관련 위키를 갱신하고 `wiki_sync_status: synced`로 바꿉니다.

--- a/docs/wiki/project/overview.md
+++ b/docs/wiki/project/overview.md
@@ -38,6 +38,8 @@
 - 시간 압박 UX를 추가하지 않습니다.
 - `docs/wiki/`가 현재형 지식층이며, 루트 문서는 호환성 포인터로만 유지합니다.
 - `docs/artifacts/`는 작업 단위별 진실의 원천입니다.
+- 작업 브랜치는 `./scripts/start_work_unit.sh`로 artifact 초안을 먼저 채우고 시작합니다.
+- PR 전 artifact completeness guard와 main push audit가 템플릿-only artifact 머지를 차단합니다.
 - 에이전트는 `wiki-first, artifacts-on-demand`로 조회합니다.
 
 ## 관련 문서

--- a/docs/wiki/project/wiki-sync-automation.md
+++ b/docs/wiki/project/wiki-sync-automation.md
@@ -4,7 +4,7 @@
 
 ## 결론
 
-- 추천 방식은 `main`을 주기적으로 확인하는 Codex cron 자동화입니다.
+- 추천 방식은 최신 `main`을 확인하는 `frdy-main-wiki-sync` 스킬 또는 이를 호출하는 Codex cron 자동화입니다.
 - GitHub Actions는 `artifact -> wiki 재합성` 같은 에이전트형 문서 작업을 수행하기에 적합하지 않습니다.
 - 따라서 CI는 guard 역할만 맡고, 실제 wiki sync는 Codex 자동화가 수행합니다.
 
@@ -13,13 +13,14 @@
 - PR 단계에서 wiki 완료를 강제하면 구현 속도와 리뷰 루프가 불필요하게 느려집니다.
 - 반대로 머지 후 자동화는 구현 맥락이 정리된 뒤 `main`에 반영된 `wiki_sync_status: pending` 작업만 골라 처리할 수 있습니다.
 - `docs/wiki/`는 현재형 재합성 문서라서, 단순 텍스트 치환보다 에이전트형 판단이 필요합니다.
+- 이 전략이 성립하려면 PR 단계에서 artifact completeness guard가 껍데기 artifact 머지를 먼저 차단해야 합니다.
 
 ## 권장 흐름
 
 1. 브랜치 작업 시작 시 artifact scaffold 생성
 2. 구현/PR/리뷰 루프 진행
 3. main 머지 완료 후 artifact가 `main` 트리에 존재하고 `wiki_sync_status: pending`
-4. Codex 자동화가 `./scripts/check_wiki_sync_guard.sh`로 pending 대상을 확인
+4. `frdy-main-wiki-sync` 또는 이를 호출하는 Codex 자동화가 `./scripts/check_wiki_sync_guard.sh`로 pending 대상을 확인
 5. `docs/wiki/skills/wiki-update.md` 절차로 영향 페이지를 재합성
 6. 완료된 work unit의 `wiki_sync_status`를 `synced`로 갱신
 

--- a/scripts/check_artifact_completeness.py
+++ b/scripts/check_artifact_completeness.py
@@ -1,0 +1,264 @@
+#!/usr/bin/env python3
+"""Validate FRDY work-unit artifacts beyond scaffold existence."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+ALLOWED_STATUS = {
+    "collecting",
+    "in_progress",
+    "ready-for-pr",
+    "in-review",
+    "merged",
+    "archived",
+}
+ALLOWED_WIKI_STATUS = {"not-started", "pending", "synced"}
+DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+TIMELINE_ENTRY_RE = re.compile(r"^- 20\d{2}-\d{2}-\d{2} \d{2}:\d{2} \| .+\S$")
+PLACEHOLDER_SNIPPETS = (
+    "<work-unit-id>",
+    "<branch-name>",
+    "YYYY-MM-DD",
+    "YYYY-MM-DD HH:MM",
+    "이 작업 단위의 목표를 1~3줄로 적습니다.",
+    "완료 기준:",
+    "아티팩트 수집 규칙, 주의사항, 후속 결정 메모를 남깁니다.",
+)
+META_BODY_SECTIONS = ("Goal", "Scope", "Acceptance", "Notes")
+PRD_SECTIONS = ("Problem", "Goal", "Constraints", "Acceptance")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Validate FRDY artifact completeness.")
+    parser.add_argument("--artifact-dir", required=True)
+    parser.add_argument(
+        "--mode",
+        choices=("progress", "pr", "main-audit"),
+        required=True,
+    )
+    parser.add_argument("--expected-id")
+    parser.add_argument("--expected-branch")
+    return parser.parse_args()
+
+
+def load_text(path: Path) -> str:
+    if not path.is_file():
+        raise FileNotFoundError(str(path))
+    return path.read_text(encoding="utf-8")
+
+
+def parse_frontmatter(text: str) -> tuple[dict[str, object], str]:
+    lines = text.splitlines()
+    if len(lines) < 3 or lines[0].strip() != "---":
+        raise ValueError("frontmatter 시작 구분자(---)를 찾지 못했습니다.")
+
+    try:
+        end_index = lines[1:].index("---") + 1
+    except ValueError as exc:
+        raise ValueError("frontmatter 종료 구분자(---)를 찾지 못했습니다.") from exc
+
+    data: dict[str, object] = {}
+    current_list_key: str | None = None
+
+    for raw_line in lines[1:end_index]:
+        line = raw_line.rstrip()
+        stripped = line.strip()
+        if not stripped:
+            continue
+        if line.startswith("  - "):
+            if current_list_key is None:
+                raise ValueError(f"리스트 항목이 키 없이 나타났습니다: {line}")
+            data.setdefault(current_list_key, [])
+            assert isinstance(data[current_list_key], list)
+            data[current_list_key].append(line[4:].strip())
+            continue
+        if ":" not in line:
+            raise ValueError(f"frontmatter 파싱에 실패했습니다: {line}")
+        key, value = line.split(":", 1)
+        key = key.strip()
+        value = value.strip()
+        if value == "":
+            if key == "wiki_targets":
+                data[key] = []
+                current_list_key = key
+                continue
+            data[key] = ""
+            current_list_key = None
+        else:
+            data[key] = value
+            current_list_key = None
+
+    body = "\n".join(lines[end_index + 1 :]).strip()
+    return data, body
+
+
+def parse_sections(text: str) -> dict[str, list[str]]:
+    sections: dict[str, list[str]] = {}
+    current: str | None = None
+
+    for raw_line in text.splitlines():
+        line = raw_line.rstrip()
+        if line.startswith("## "):
+            current = line[3:].strip()
+            sections.setdefault(current, [])
+            continue
+        if current is not None:
+            sections[current].append(line)
+
+    return sections
+
+
+def compact_lines(lines: list[str]) -> list[str]:
+    return [line.strip() for line in lines if line.strip()]
+
+
+def section_text(lines: list[str]) -> str:
+    return " ".join(compact_lines(lines))
+
+
+def validate_no_placeholders(text: str, label: str, errors: list[str]) -> None:
+    for snippet in PLACEHOLDER_SNIPPETS:
+        if snippet in text:
+            errors.append(f"{label}에 템플릿 플레이스홀더가 남아 있습니다: {snippet}")
+
+
+def validate_frontmatter(
+    data: dict[str, object],
+    *,
+    expected_id: str | None,
+    expected_branch: str | None,
+    mode: str,
+    errors: list[str],
+) -> None:
+    artifact_id = str(data.get("id", "")).strip()
+    branch = str(data.get("branch", "")).strip()
+    status = str(data.get("status", "")).strip()
+    wiki_status = str(data.get("wiki_sync_status", "")).strip()
+    created_at = str(data.get("created_at", "")).strip()
+    updated_at = str(data.get("updated_at", "")).strip()
+    related_pr = str(data.get("related_pr", "")).strip()
+
+    if expected_id and artifact_id != expected_id:
+        errors.append(f"meta.md의 id가 예상값과 다릅니다. expected={expected_id}, actual={artifact_id}")
+    if expected_branch and branch != expected_branch:
+        errors.append(f"meta.md의 branch가 예상값과 다릅니다. expected={expected_branch}, actual={branch}")
+    if not artifact_id:
+        errors.append("meta.md의 id가 비어 있습니다.")
+    if not branch:
+        errors.append("meta.md의 branch가 비어 있습니다.")
+    if status not in ALLOWED_STATUS:
+        errors.append(f"meta.md의 status가 허용값이 아닙니다: {status}")
+    if wiki_status not in ALLOWED_WIKI_STATUS:
+        errors.append(f"meta.md의 wiki_sync_status가 허용값이 아닙니다: {wiki_status}")
+    if not DATE_RE.match(created_at):
+        errors.append(f"meta.md의 created_at 형식이 올바르지 않습니다: {created_at}")
+    if not DATE_RE.match(updated_at):
+        errors.append(f"meta.md의 updated_at 형식이 올바르지 않습니다: {updated_at}")
+
+    if mode in {"progress", "pr"} and status == "collecting":
+        errors.append("scaffold만 만든 collecting 상태로는 작업을 진행할 수 없습니다.")
+    if mode in {"progress", "pr"} and wiki_status == "not-started":
+        errors.append("작업 중 artifact는 wiki_sync_status: pending 또는 synced 여야 합니다.")
+    if mode == "pr" and status == "in-review" and not related_pr:
+        errors.append("status가 in-review이면 related_pr를 채워야 합니다.")
+    if mode == "pr" and status not in {"in_progress", "ready-for-pr", "in-review"}:
+        errors.append(f"PR 검증 시 status는 in_progress/ready-for-pr/in-review 중 하나여야 합니다: {status}")
+
+
+def validate_markdown_sections(
+    body: str,
+    *,
+    required_sections: tuple[str, ...],
+    label: str,
+    mode: str,
+    errors: list[str],
+) -> None:
+    sections = parse_sections(body)
+    for section in required_sections:
+        if section not in sections:
+            errors.append(f"{label}에 필수 섹션이 없습니다: {section}")
+            continue
+        text = section_text(sections[section])
+        if len(text) < 12:
+            errors.append(f"{label}의 {section} 섹션 내용이 너무 짧거나 비어 있습니다.")
+
+    if label == "meta.md 본문" and mode == "pr":
+        scope_text = section_text(sections.get("Scope", []))
+        if "포함 범위" not in scope_text or "제외 범위" not in scope_text:
+            errors.append("meta.md의 Scope 섹션에는 포함/제외 범위가 모두 명시되어야 합니다.")
+
+
+def validate_timeline(text: str, *, mode: str, errors: list[str]) -> None:
+    validate_no_placeholders(text, "timeline.md", errors)
+    entries = [line.strip() for line in text.splitlines() if TIMELINE_ENTRY_RE.match(line.strip())]
+    if not entries:
+        errors.append("timeline.md에 실제 타임라인 항목이 없습니다.")
+        return
+    if mode == "pr" and len(entries) < 2:
+        errors.append("PR 검증 전에는 timeline.md에 최소 2개 이상의 실제 진행 기록이 필요합니다.")
+
+
+def main() -> int:
+    args = parse_args()
+    artifact_dir = Path(args.artifact_dir).resolve()
+    errors: list[str] = []
+
+    meta_path = artifact_dir / "meta.md"
+    prd_path = artifact_dir / "prd.md"
+    timeline_path = artifact_dir / "timeline.md"
+
+    for required_path in (meta_path, prd_path, timeline_path):
+        if not required_path.is_file():
+            errors.append(f"필수 파일이 없습니다: {required_path}")
+
+    if errors:
+        print("\n".join(errors), file=sys.stderr)
+        return 1
+
+    meta_text = load_text(meta_path)
+    prd_text = load_text(prd_path)
+    timeline_text = load_text(timeline_path)
+
+    validate_no_placeholders(meta_text, "meta.md", errors)
+    validate_no_placeholders(prd_text, "prd.md", errors)
+
+    meta_frontmatter, meta_body = parse_frontmatter(meta_text)
+    validate_frontmatter(
+        meta_frontmatter,
+        expected_id=args.expected_id,
+        expected_branch=args.expected_branch,
+        mode=args.mode,
+        errors=errors,
+    )
+    validate_markdown_sections(
+        meta_body,
+        required_sections=META_BODY_SECTIONS,
+        label="meta.md 본문",
+        mode=args.mode,
+        errors=errors,
+    )
+    validate_markdown_sections(
+        prd_text,
+        required_sections=PRD_SECTIONS,
+        label="prd.md",
+        mode=args.mode,
+        errors=errors,
+    )
+    validate_timeline(timeline_text, mode=args.mode, errors=errors)
+
+    if errors:
+        print("artifact completeness 검증 실패:", file=sys.stderr)
+        for error in errors:
+            print(f"- {error}", file=sys.stderr)
+        return 1
+
+    print(f"artifact completeness 통과: {artifact_dir}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_artifact_completeness.py
+++ b/scripts/check_artifact_completeness.py
@@ -19,12 +19,12 @@ ALLOWED_STATUS = {
 ALLOWED_WIKI_STATUS = {"not-started", "pending", "synced"}
 DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
 TIMELINE_ENTRY_RE = re.compile(r"^- 20\d{2}-\d{2}-\d{2} \d{2}:\d{2} \| .+\S$")
-PLACEHOLDER_TOKENS = (
-    "<work-unit-id>",
-    "<branch-name>",
-    "YYYY-MM-DD",
-    "YYYY-MM-DD HH:MM",
-)
+FRONTMATTER_PLACEHOLDERS = {
+    "id": "<work-unit-id>",
+    "branch": "<branch-name>",
+    "created_at": "YYYY-MM-DD",
+    "updated_at": "YYYY-MM-DD",
+}
 PLACEHOLDER_LINE_PATTERNS = (
     (re.compile(r"^(?:-\s*)?이 작업 단위의 목표를 1~3줄로 적습니다\.$"), "이 작업 단위의 목표를 1~3줄로 적습니다."),
     (re.compile(r"^(?:-\s*)?완료 기준:$"), "완료 기준:"),
@@ -32,6 +32,7 @@ PLACEHOLDER_LINE_PATTERNS = (
         re.compile(r"^(?:-\s*)?아티팩트 수집 규칙, 주의사항, 후속 결정 메모를 남깁니다\.$"),
         "아티팩트 수집 규칙, 주의사항, 후속 결정 메모를 남깁니다.",
     ),
+    (re.compile(r"^- YYYY-MM-DD HH:MM \| .+$"), "YYYY-MM-DD HH:MM"),
 )
 META_BODY_SECTIONS = ("Goal", "Scope", "Acceptance", "Notes")
 PRD_SECTIONS = ("Problem", "Goal", "Constraints", "Acceptance")
@@ -126,9 +127,6 @@ def section_text(lines: list[str]) -> str:
 
 
 def validate_no_placeholders(text: str, label: str, errors: list[str]) -> None:
-    for snippet in PLACEHOLDER_TOKENS:
-        if snippet in text:
-            errors.append(f"{label}에 템플릿 플레이스홀더가 남아 있습니다: {snippet}")
     for raw_line in text.splitlines():
         stripped = raw_line.strip()
         for pattern, snippet in PLACEHOLDER_LINE_PATTERNS:
@@ -151,6 +149,11 @@ def validate_frontmatter(
     created_at = str(data.get("created_at", "")).strip()
     updated_at = str(data.get("updated_at", "")).strip()
     related_pr = str(data.get("related_pr", "")).strip()
+
+    for key, snippet in FRONTMATTER_PLACEHOLDERS.items():
+        value = str(data.get(key, "")).strip()
+        if value == snippet:
+            errors.append(f"meta.md의 {key}에 템플릿 플레이스홀더가 남아 있습니다: {snippet}")
 
     if expected_id and artifact_id != expected_id:
         errors.append(f"meta.md의 id가 예상값과 다릅니다. expected={expected_id}, actual={artifact_id}")

--- a/scripts/check_artifact_completeness.py
+++ b/scripts/check_artifact_completeness.py
@@ -126,6 +126,27 @@ def section_text(lines: list[str]) -> str:
     return " ".join(compact_lines(lines))
 
 
+def require_prefixed_value(
+    lines: list[str],
+    *,
+    prefix: str,
+    label: str,
+    errors: list[str],
+) -> None:
+    for raw_line in compact_lines(lines):
+        normalized = raw_line
+        if normalized.startswith("- "):
+            normalized = normalized[2:].strip()
+        if not normalized.startswith(prefix):
+            continue
+        value = normalized[len(prefix) :].strip()
+        if value:
+            return
+        errors.append(f"{label}에 `{prefix}` 뒤 실제 내용이 있어야 합니다.")
+        return
+    errors.append(f"{label}에 `{prefix}` 항목이 없습니다.")
+
+
 def validate_no_placeholders(text: str, label: str, errors: list[str]) -> None:
     for raw_line in text.splitlines():
         stripped = raw_line.strip()
@@ -200,9 +221,9 @@ def validate_markdown_sections(
             errors.append(f"{label}의 {section} 섹션 내용이 너무 짧거나 비어 있습니다.")
 
     if label == "meta.md 본문" and mode == "pr":
-        scope_text = section_text(sections.get("Scope", []))
-        if "포함 범위" not in scope_text or "제외 범위" not in scope_text:
-            errors.append("meta.md의 Scope 섹션에는 포함/제외 범위가 모두 명시되어야 합니다.")
+        scope_lines = sections.get("Scope", [])
+        require_prefixed_value(scope_lines, prefix="포함 범위:", label="meta.md의 Scope 섹션", errors=errors)
+        require_prefixed_value(scope_lines, prefix="제외 범위:", label="meta.md의 Scope 섹션", errors=errors)
 
 
 def validate_timeline(text: str, *, mode: str, errors: list[str]) -> None:

--- a/scripts/check_artifact_completeness.py
+++ b/scripts/check_artifact_completeness.py
@@ -19,14 +19,19 @@ ALLOWED_STATUS = {
 ALLOWED_WIKI_STATUS = {"not-started", "pending", "synced"}
 DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
 TIMELINE_ENTRY_RE = re.compile(r"^- 20\d{2}-\d{2}-\d{2} \d{2}:\d{2} \| .+\S$")
-PLACEHOLDER_SNIPPETS = (
+PLACEHOLDER_TOKENS = (
     "<work-unit-id>",
     "<branch-name>",
     "YYYY-MM-DD",
     "YYYY-MM-DD HH:MM",
-    "이 작업 단위의 목표를 1~3줄로 적습니다.",
-    "완료 기준:",
-    "아티팩트 수집 규칙, 주의사항, 후속 결정 메모를 남깁니다.",
+)
+PLACEHOLDER_LINE_PATTERNS = (
+    (re.compile(r"^(?:-\s*)?이 작업 단위의 목표를 1~3줄로 적습니다\.$"), "이 작업 단위의 목표를 1~3줄로 적습니다."),
+    (re.compile(r"^(?:-\s*)?완료 기준:$"), "완료 기준:"),
+    (
+        re.compile(r"^(?:-\s*)?아티팩트 수집 규칙, 주의사항, 후속 결정 메모를 남깁니다\.$"),
+        "아티팩트 수집 규칙, 주의사항, 후속 결정 메모를 남깁니다.",
+    ),
 )
 META_BODY_SECTIONS = ("Goal", "Scope", "Acceptance", "Notes")
 PRD_SECTIONS = ("Problem", "Goal", "Constraints", "Acceptance")
@@ -121,9 +126,14 @@ def section_text(lines: list[str]) -> str:
 
 
 def validate_no_placeholders(text: str, label: str, errors: list[str]) -> None:
-    for snippet in PLACEHOLDER_SNIPPETS:
+    for snippet in PLACEHOLDER_TOKENS:
         if snippet in text:
             errors.append(f"{label}에 템플릿 플레이스홀더가 남아 있습니다: {snippet}")
+    for raw_line in text.splitlines():
+        stripped = raw_line.strip()
+        for pattern, snippet in PLACEHOLDER_LINE_PATTERNS:
+            if pattern.fullmatch(stripped):
+                errors.append(f"{label}에 템플릿 플레이스홀더가 남아 있습니다: {snippet}")
 
 
 def validate_frontmatter(

--- a/scripts/check_artifact_guard.sh
+++ b/scripts/check_artifact_guard.sh
@@ -24,13 +24,13 @@ fi
 
 work_unit_id="$(printf "%s" "$branch" | tr '/[:upper:]' '-[:lower:]' | sed 's/[^a-z0-9._-]/-/g')"
 artifact_dir="$ROOT_DIR/docs/artifacts/$work_unit_id"
-mapfile -t changed_artifact_dirs < <(
+changed_artifact_dirs="$(
   printf "%s\n" "$changed_files" \
     | grep -E '^docs/artifacts/[^/]+/' \
     | grep -Ev '^docs/artifacts/_template/' \
     | awk -F/ '{print $1 "/" $2 "/" $3}' \
-    | sort -u
-)
+    | sort -u || true
+)"
 
 python3 "$ROOT_DIR/scripts/check_artifact_completeness.py" \
   --artifact-dir "$artifact_dir" \
@@ -38,7 +38,8 @@ python3 "$ROOT_DIR/scripts/check_artifact_completeness.py" \
   --expected-id "$work_unit_id" \
   --expected-branch "$branch"
 
-for changed_artifact_dir in "${changed_artifact_dirs[@]}"; do
+while IFS= read -r changed_artifact_dir; do
+  [[ -z "$changed_artifact_dir" ]] && continue
   if [[ "$ROOT_DIR/$changed_artifact_dir" == "$artifact_dir" ]]; then
     continue
   fi
@@ -46,6 +47,6 @@ for changed_artifact_dir in "${changed_artifact_dirs[@]}"; do
     --artifact-dir "$ROOT_DIR/$changed_artifact_dir" \
     --mode pr \
     --expected-id "$(basename "$changed_artifact_dir")"
-done
+done <<< "$changed_artifact_dirs"
 
 echo "artifact guard 통과"

--- a/scripts/check_artifact_guard.sh
+++ b/scripts/check_artifact_guard.sh
@@ -10,9 +10,14 @@ if ! git rev-parse --verify "$BASE_REF" >/dev/null 2>&1; then
   exit 0
 fi
 
-branch="${GITHUB_HEAD_REF:-$(git branch --show-current)}"
-if [[ -z "$branch" || "$branch" == "main" ]]; then
+head_ref="${GITHUB_HEAD_REF:-}"
+branch="${head_ref:-$(git branch --show-current)}"
+if [[ -z "$branch" ]]; then
   echo "artifact guard를 수행할 작업 브랜치를 확인할 수 없습니다." >&2
+  exit 0
+fi
+if [[ -z "$head_ref" && "$branch" == "main" ]]; then
+  echo "로컬 main에서는 artifact guard를 건너뜁니다." >&2
   exit 0
 fi
 

--- a/scripts/check_artifact_guard.sh
+++ b/scripts/check_artifact_guard.sh
@@ -10,9 +10,9 @@ if ! git rev-parse --verify "$BASE_REF" >/dev/null 2>&1; then
   exit 0
 fi
 
-branch="$(git branch --show-current)"
+branch="${GITHUB_HEAD_REF:-$(git branch --show-current)}"
 if [[ -z "$branch" || "$branch" == "main" ]]; then
-  echo "main 또는 detached 상태에서는 artifact guard를 건너뜁니다."
+  echo "artifact guard를 수행할 작업 브랜치를 확인할 수 없습니다." >&2
   exit 0
 fi
 
@@ -22,34 +22,30 @@ if [[ -z "$changed_files" ]]; then
   exit 0
 fi
 
-meaningful_changed="$(printf "%s\n" "$changed_files" \
-  | grep -E '^(src|data|assets|tests)/' || true)"
-
-if [[ -z "$meaningful_changed" ]]; then
-  echo "코드/데이터/테스트 변경이 없어 artifact guard를 건너뜁니다."
-  exit 0
-fi
-
 work_unit_id="$(printf "%s" "$branch" | tr '/[:upper:]' '-[:lower:]' | sed 's/[^a-z0-9._-]/-/g')"
 artifact_dir="$ROOT_DIR/docs/artifacts/$work_unit_id"
-meta_file="$artifact_dir/meta.md"
+mapfile -t changed_artifact_dirs < <(
+  printf "%s\n" "$changed_files" \
+    | grep -E '^docs/artifacts/[^/]+/' \
+    | grep -Ev '^docs/artifacts/_template/' \
+    | awk -F/ '{print $1 "/" $2 "/" $3}' \
+    | sort -u
+)
 
-if [[ ! -f "$meta_file" ]]; then
-  echo "실패: 코드/데이터 변경이 있지만 작업 단위 artifact가 없습니다." >&2
-  echo "브랜치: $branch" >&2
-  echo "예상 경로: $artifact_dir" >&2
-  echo "먼저 ./scripts/ensure_artifact_scaffold.sh 를 실행하세요." >&2
-  exit 1
-fi
+python3 "$ROOT_DIR/scripts/check_artifact_completeness.py" \
+  --artifact-dir "$artifact_dir" \
+  --mode pr \
+  --expected-id "$work_unit_id" \
+  --expected-branch "$branch"
 
-if ! grep -q '^wiki_sync_status:' "$meta_file"; then
-  echo "실패: $meta_file 에 wiki_sync_status가 없습니다." >&2
-  exit 1
-fi
-
-if ! grep -q '^status:' "$meta_file"; then
-  echo "실패: $meta_file 에 status가 없습니다." >&2
-  exit 1
-fi
+for changed_artifact_dir in "${changed_artifact_dirs[@]}"; do
+  if [[ "$ROOT_DIR/$changed_artifact_dir" == "$artifact_dir" ]]; then
+    continue
+  fi
+  python3 "$ROOT_DIR/scripts/check_artifact_completeness.py" \
+    --artifact-dir "$ROOT_DIR/$changed_artifact_dir" \
+    --mode pr \
+    --expected-id "$(basename "$changed_artifact_dir")"
+done
 
 echo "artifact guard 통과"

--- a/scripts/check_artifact_guard.sh
+++ b/scripts/check_artifact_guard.sh
@@ -45,7 +45,7 @@ while IFS= read -r changed_artifact_dir; do
   fi
   python3 "$ROOT_DIR/scripts/check_artifact_completeness.py" \
     --artifact-dir "$ROOT_DIR/$changed_artifact_dir" \
-    --mode pr \
+    --mode main-audit \
     --expected-id "$(basename "$changed_artifact_dir")"
 done <<< "$changed_artifact_dirs"
 

--- a/scripts/check_artifact_progress.sh
+++ b/scripts/check_artifact_progress.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+branch="${1:-${GITHUB_HEAD_REF:-$(git branch --show-current)}}"
+if [[ -z "$branch" || "$branch" == "main" ]]; then
+  echo "현재 브랜치에서 artifact progress 검사를 수행할 수 없습니다." >&2
+  exit 1
+fi
+
+work_unit_id="$(printf "%s" "$branch" | tr '/[:upper:]' '-[:lower:]' | sed 's/[^a-z0-9._-]/-/g')"
+artifact_dir="$ROOT_DIR/docs/artifacts/$work_unit_id"
+
+python3 "$ROOT_DIR/scripts/check_artifact_completeness.py" \
+  --artifact-dir "$artifact_dir" \
+  --mode progress \
+  --expected-id "$work_unit_id" \
+  --expected-branch "$branch"

--- a/scripts/check_main_artifact_audit.sh
+++ b/scripts/check_main_artifact_audit.sh
@@ -21,15 +21,15 @@ fi
 meaningful_changed="$(printf "%s\n" "$changed_files" \
   | grep -Ev '^(docs/artifacts/|\.gitignore$)' || true)"
 
-mapfile -t artifact_dirs < <(
+artifact_dirs="$(
   printf "%s\n" "$changed_files" \
     | grep -E '^docs/artifacts/[^/]+/' \
     | grep -Ev '^docs/artifacts/_template/' \
     | awk -F/ '{print $1 "/" $2 "/" $3}' \
-    | sort -u
-)
+    | sort -u || true
+)"
 
-if [[ -n "$meaningful_changed" && "${#artifact_dirs[@]}" -eq 0 ]]; then
+if [[ -n "$meaningful_changed" && -z "$artifact_dirs" ]]; then
   echo "실패: main에 반영된 변경 중 artifact 갱신이 없는 항목이 있습니다." >&2
   echo "--- 변경 파일 ---" >&2
   printf "%s\n" "$meaningful_changed" >&2
@@ -37,17 +37,18 @@ if [[ -n "$meaningful_changed" && "${#artifact_dirs[@]}" -eq 0 ]]; then
   exit 1
 fi
 
-if [[ "${#artifact_dirs[@]}" -eq 0 ]]; then
+if [[ -z "$artifact_dirs" ]]; then
   echo "artifact 변경이 없어 main artifact audit를 통과합니다."
   exit 0
 fi
 
-for artifact_dir in "${artifact_dirs[@]}"; do
+while IFS= read -r artifact_dir; do
+  [[ -z "$artifact_dir" ]] && continue
   work_unit_id="$(basename "$artifact_dir")"
   python3 "$ROOT_DIR/scripts/check_artifact_completeness.py" \
     --artifact-dir "$ROOT_DIR/$artifact_dir" \
     --mode main-audit \
     --expected-id "$work_unit_id"
-done
+done <<< "$artifact_dirs"
 
 echo "main artifact audit 통과"

--- a/scripts/check_main_artifact_audit.sh
+++ b/scripts/check_main_artifact_audit.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+BASE_REF="${1:-${GITHUB_EVENT_BEFORE:-HEAD~1}}"
+HEAD_REF="${2:-HEAD}"
+
+if ! git rev-parse --verify "$BASE_REF" >/dev/null 2>&1; then
+  echo "기준 커밋($BASE_REF)을 찾지 못해 main artifact audit를 건너뜁니다."
+  exit 0
+fi
+
+changed_files="$(git diff --name-only "${BASE_REF}..${HEAD_REF}")"
+if [[ -z "$changed_files" ]]; then
+  echo "변경 파일이 없어 main artifact audit를 건너뜁니다."
+  exit 0
+fi
+
+meaningful_changed="$(printf "%s\n" "$changed_files" \
+  | grep -Ev '^(docs/artifacts/|\.gitignore$)' || true)"
+
+mapfile -t artifact_dirs < <(
+  printf "%s\n" "$changed_files" \
+    | grep -E '^docs/artifacts/[^/]+/' \
+    | grep -Ev '^docs/artifacts/_template/' \
+    | awk -F/ '{print $1 "/" $2 "/" $3}' \
+    | sort -u
+)
+
+if [[ -n "$meaningful_changed" && "${#artifact_dirs[@]}" -eq 0 ]]; then
+  echo "실패: main에 반영된 변경 중 artifact 갱신이 없는 항목이 있습니다." >&2
+  echo "--- 변경 파일 ---" >&2
+  printf "%s\n" "$meaningful_changed" >&2
+  echo "---------------" >&2
+  exit 1
+fi
+
+if [[ "${#artifact_dirs[@]}" -eq 0 ]]; then
+  echo "artifact 변경이 없어 main artifact audit를 통과합니다."
+  exit 0
+fi
+
+for artifact_dir in "${artifact_dirs[@]}"; do
+  work_unit_id="$(basename "$artifact_dir")"
+  python3 "$ROOT_DIR/scripts/check_artifact_completeness.py" \
+    --artifact-dir "$ROOT_DIR/$artifact_dir" \
+    --mode main-audit \
+    --expected-id "$work_unit_id"
+done
+
+echo "main artifact audit 통과"

--- a/scripts/start_work_unit.sh
+++ b/scripts/start_work_unit.sh
@@ -1,0 +1,174 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+branch="${GITHUB_HEAD_REF:-$(git branch --show-current)}"
+issue=""
+summary=""
+scope_in=""
+scope_out=""
+constraints=""
+acceptance=""
+notes=""
+force=0
+wiki_targets=()
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --branch)
+      branch="$2"
+      shift 2
+      ;;
+    --issue)
+      issue="$2"
+      shift 2
+      ;;
+    --summary)
+      summary="$2"
+      shift 2
+      ;;
+    --scope-in)
+      scope_in="$2"
+      shift 2
+      ;;
+    --scope-out)
+      scope_out="$2"
+      shift 2
+      ;;
+    --constraints)
+      constraints="$2"
+      shift 2
+      ;;
+    --acceptance)
+      acceptance="$2"
+      shift 2
+      ;;
+    --notes)
+      notes="$2"
+      shift 2
+      ;;
+    --wiki-target)
+      wiki_targets+=("$2")
+      shift 2
+      ;;
+    --force)
+      force=1
+      shift
+      ;;
+    *)
+      echo "알 수 없는 옵션: $1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -z "$branch" || "$branch" == "main" ]]; then
+  echo "start_work_unit은 main이 아닌 작업 브랜치에서 실행해야 합니다." >&2
+  exit 1
+fi
+
+if [[ "$branch" != "$(git branch --show-current)" ]]; then
+  echo "현재 브랜치와 --branch 값이 다릅니다. 먼저 대상 브랜치로 switch 하세요." >&2
+  exit 1
+fi
+
+if [[ -z "$summary" || ${#summary} -lt 10 ]]; then
+  echo "--summary는 10자 이상으로 입력해야 합니다." >&2
+  exit 1
+fi
+
+work_unit_id="$(printf "%s" "$branch" | tr '/[:upper:]' '-[:lower:]' | sed 's/[^a-z0-9._-]/-/g')"
+artifact_dir="$("$ROOT_DIR/scripts/ensure_artifact_scaffold.sh" "$branch")"
+meta_path="$artifact_dir/meta.md"
+prd_path="$artifact_dir/prd.md"
+timeline_path="$artifact_dir/timeline.md"
+
+if [[ "$force" -ne 1 ]] && ! grep -q "이 작업 단위의 목표를 1~3줄로 적습니다." "$meta_path"; then
+  echo "이미 채워진 artifact가 있습니다. 덮어쓰려면 --force를 사용하세요." >&2
+  exit 1
+fi
+
+today="$(date +%F)"
+timestamp="$(date '+%F %H:%M')"
+issue_ref=""
+if [[ -n "$issue" ]]; then
+  issue_ref="$issue"
+  if [[ "$issue_ref" != \#* ]]; then
+    issue_ref="#$issue_ref"
+  fi
+fi
+
+if [[ -z "$scope_in" ]]; then
+  scope_in="$summary"
+fi
+if [[ -z "$scope_out" ]]; then
+  scope_out="현재 작업 목적과 직접 관련 없는 주변 정리, 별도 기능 확장, 후속 이슈 범위"
+fi
+if [[ -z "$constraints" ]]; then
+  constraints="기존 artifact/wiki 운영 규칙과 CI 흐름을 깨지 않는 선에서 최소 범위로 정리합니다."
+fi
+if [[ -z "$acceptance" ]]; then
+  acceptance="$summary"
+fi
+if [[ -z "$notes" ]]; then
+  notes="브랜치 시작 직후 artifact 초안을 채워 껍데기 상태로 작업이 진행되지 않게 합니다."
+fi
+
+{
+  printf '%s\n' '---'
+  printf 'id: %s\n' "$work_unit_id"
+  printf 'branch: %s\n' "$branch"
+  printf '%s\n' 'status: in_progress'
+  printf '%s\n' 'wiki_sync_status: pending'
+  printf 'created_at: %s\n' "$today"
+  printf 'updated_at: %s\n' "$today"
+  printf 'related_issue: %s\n' "$issue_ref"
+  printf '%s\n' 'related_pr:'
+  printf '%s\n' 'merge_commit:'
+  printf '%s\n' 'wiki_targets:'
+  if [[ "${#wiki_targets[@]}" -eq 0 ]]; then
+    printf '%s\n' '  - docs/wiki/project/overview.md'
+  else
+    for target in "${wiki_targets[@]}"; do
+      printf '  - %s\n' "$target"
+    done
+  fi
+  printf '%s\n\n' '---'
+  printf '%s\n\n' '# Work Unit Meta'
+  printf '%s\n\n' '## Goal'
+  printf -- '- %s\n' "$summary"
+  printf -- '- 이 브랜치의 변경과 검증 결과를 artifact에 지속적으로 누적합니다.\n\n'
+  printf '%s\n\n' '## Scope'
+  printf -- '- 포함 범위: %s\n' "$scope_in"
+  printf -- '- 제외 범위: %s\n\n' "$scope_out"
+  printf '%s\n\n' '## Acceptance'
+  printf -- '- %s\n' "$acceptance"
+  printf -- '- PR 전 `./scripts/check_artifact_progress.sh`와 `./scripts/check_artifact_guard.sh`를 통과합니다.\n\n'
+  printf '%s\n\n' '## Notes'
+  printf -- '- %s\n' "$notes"
+} > "$meta_path"
+
+{
+  printf '%s\n\n' '# PRD'
+  printf -- '- work-unit: %s\n' "$work_unit_id"
+  printf -- '- branch: %s\n\n' "$branch"
+  printf '%s\n\n' '## Problem'
+  printf -- '- %s\n\n' "$summary"
+  printf '%s\n\n' '## Goal'
+  printf -- '- %s\n\n' "$summary"
+  printf '%s\n\n' '## Constraints'
+  printf -- '- %s\n\n' "$constraints"
+  printf '%s\n\n' '## Acceptance'
+  printf -- '- %s\n' "$acceptance"
+} > "$prd_path"
+
+{
+  printf '%s\n\n' '# Timeline'
+  printf -- '- %s | 작업 시작 및 artifact 초기화\n' "$timestamp"
+  printf -- '- %s | 작업 요약 확정: %s\n' "$timestamp" "$summary"
+} > "$timeline_path"
+
+"$ROOT_DIR/scripts/check_artifact_progress.sh" "$branch"
+echo "$artifact_dir"


### PR DESCRIPTION
## 요약
- `start_work_unit.sh`를 추가해 브랜치 시작 시 artifact 초안 생성과 진행 상태 검사를 한 번에 묶었습니다.
- `check_artifact_completeness.py`, `check_artifact_progress.sh`, `check_main_artifact_audit.sh`를 도입해 빈 껍데기 artifact와 main 머지 누수를 막도록 강화했습니다.
- CI와 문서를 갱신하고, 최신 `main` 기준으로 wiki를 동기화하는 `frdy-main-wiki-sync` 스킬을 설계/설치했습니다.

## 검증
- `./scripts/check_artifact_progress.sh`
- `./scripts/check_artifact_guard.sh origin/main`
- `./scripts/check_main_artifact_audit.sh origin/main HEAD`
- `python3 -m py_compile scripts/check_artifact_completeness.py`
- `bash -n scripts/start_work_unit.sh scripts/check_artifact_progress.sh scripts/check_artifact_guard.sh scripts/check_main_artifact_audit.sh`
- `./scripts/run_tests.sh`
- `./scripts/check_love.sh`
